### PR TITLE
Improve ASCII case conversions

### DIFF
--- a/src/fen.rs
+++ b/src/fen.rs
@@ -72,7 +72,6 @@
 //! [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
 
 use std::str::FromStr;
-use std::ascii::AsciiExt;
 use std::fmt;
 use std::char;
 use std::error::Error;
@@ -363,10 +362,10 @@ impl Fen {
                     let candidates = Bitboard::relative_rank(color, 0) &
                                      result.board.by_piece(color.rook());
 
-                    let flag = match (ch as char).to_ascii_lowercase() {
-                        'k' => candidates.last(),
-                        'q' => candidates.first(),
-                        file @ 'a' ... 'h' => {
+                    let flag = match ch | 32 {
+                        b'k' => candidates.last(),
+                        b'q' => candidates.first(),
+                        file @ b'a' ... b'h' => {
                             (candidates & Bitboard::file((file as u8 - b'a') as i8)).first()
                         },
                         _ => return Err(FenError::InvalidCastling),

--- a/src/san.rs
+++ b/src/san.rs
@@ -96,7 +96,6 @@ use position::{Position, Outcome};
 use movelist::MoveList;
 
 use std::fmt;
-use std::ascii::AsciiExt;
 use option_filter::OptionFilterExt;
 use std::str::FromStr;
 use std::error::Error;
@@ -341,7 +340,7 @@ impl fmt::Display for San {
         match *self {
             San::Normal { role, file, rank, capture, to, promotion } => {
                 if role != Role::Pawn {
-                    write!(f, "{}", role.char().to_ascii_uppercase())?;
+                    write!(f, "{}", (32 ^ role.char() as u8) as char)?;
                 }
                 if let Some(file) = file {
                     write!(f, "{}", (b'a' + file as u8) as char)?;
@@ -354,14 +353,14 @@ impl fmt::Display for San {
                 }
                 write!(f, "{}", to)?;
                 if let Some(promotion) = promotion {
-                    write!(f, "={}", promotion.char().to_ascii_uppercase())?;
+                    write!(f, "={}", (32 ^ promotion.char() as u8) as char)?;
                 }
                 Ok(())
             },
             San::Castle(CastlingSide::KingSide) => write!(f, "O-O"),
             San::Castle(CastlingSide::QueenSide) => write!(f, "O-O-O"),
             San::Put { role: Role::Pawn, to } => write!(f, "@{}", to),
-            San::Put { role, to } => write!(f, "{}@{}", role.char().to_ascii_uppercase(), to),
+            San::Put { role, to } => write!(f, "{}@{}", (32 ^ role.char() as u8) as char, to),
             San::Null => write!(f, "--"),
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt;
-use std::ascii::AsciiExt;
 use std::char;
 use std::ops;
 
@@ -138,12 +137,12 @@ pub struct Piece {
 
 impl Piece {
     pub fn char(&self) -> char {
-        self.color.fold(self.role.char().to_ascii_uppercase(), self.role.char())
+        self.color.fold((32 ^ self.role.char() as u8) as char, self.role.char())
     }
 
     pub fn from_char(ch: char) -> Option<Piece> {
         Role::from_char(ch).map(|role| {
-            role.of(Color::from_bool(ch == ch.to_ascii_uppercase()))
+            role.of(Color::from_bool(32 & ch as u8 == 0))
         })
     }
 }
@@ -205,13 +204,13 @@ impl fmt::Display for Move {
         match *self {
             Move::Normal { role, from, capture, to, promotion } => {
                 if role != Role::Pawn {
-                    write!(f, "{}", role.char().to_ascii_uppercase())?;
+                    write!(f, "{}", (32 ^ role.char() as u8) as char)?;
                 }
 
                 write!(f, "{}{}{}", from, if capture.is_some() { 'x' } else { '-' }, to)?;
 
                 if let Some(p) = promotion {
-                    write!(f, "={}", p.char().to_ascii_uppercase())?;
+                    write!(f, "={}", (32 ^ p.char() as u8) as char)?;
                 }
 
                 Ok(())
@@ -227,7 +226,7 @@ impl fmt::Display for Move {
                 }
             },
             Move::Put { role, to } => {
-                write!(f, "{}@{}", role.char().to_ascii_uppercase(), to)
+                write!(f, "{}@{}", (32 ^ role.char() as u8) as char, to)
             },
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -95,13 +95,13 @@ pub enum Role {
 
 impl Role {
     pub fn from_char(ch: char) -> Option<Role> {
-        match ch {
-            'p' | 'P' => Some(Role::Pawn),
-            'n' | 'N' => Some(Role::Knight),
-            'b' | 'B' => Some(Role::Bishop),
-            'r' | 'R' => Some(Role::Rook),
-            'q' | 'Q' => Some(Role::Queen),
-            'k' | 'K' => Some(Role::King),
+        match 32 | ch as u8 {
+            b'p' => Some(Role::Pawn),
+            b'n' => Some(Role::Knight),
+            b'b' => Some(Role::Bishop),
+            b'r' => Some(Role::Rook),
+            b'q' => Some(Role::Queen),
+            b'k' => Some(Role::King),
             _ => None,
         }
     }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -91,7 +91,6 @@
 //! [`Uci`]: enum.Uci.html
 
 use std::fmt;
-use std::ascii::AsciiExt;
 use std::str::FromStr;
 use std::error::Error;
 
@@ -156,7 +155,7 @@ impl fmt::Display for Uci {
             Uci::Normal { from, to, promotion: Some(promotion) } =>
                 write!(f, "{}{}{}", from, to, promotion.char()),
             Uci::Put { to, role } =>
-                write!(f, "{}@{}", role.char().to_ascii_uppercase(), to),
+                write!(f, "{}@{}", (32 ^ role.char() as u8) as char, to),
             Uci::Null =>
                 write!(f, "0000")
         }


### PR DESCRIPTION
Uses simple bit operations to perform conversions and comparisons.

Removes use of `std::ascii::AsciiExt`, which uses a lookup table (generally slower).