### PR TITLE
Add last to CarryRippler

### DIFF
--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -468,7 +468,7 @@ impl Iterator for CarryRippler {
 
     #[inline]
     fn last(self) -> Option<Bitboard> {
-        if subset != 0 || self.first {
+        if self.subset != 0 || self.first {
             Some(Bitboard(self.bb))
         } else {
             None

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -465,6 +465,15 @@ impl Iterator for CarryRippler {
             None
         }
     }
+
+    #[inline]
+    fn last(self) -> Option<Bitboard> {
+        if subset != 0 || self.first {
+            Some(Bitboard(self.bb))
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The last iteration is always the initial set.

This saves _a lot_ of time compared to the default implementation which is just iterating until finished.