### PR TITLE
Generate tests using macro

### DIFF
--- a/tests/perft.rs
+++ b/tests/perft.rs
@@ -65,44 +65,26 @@ where
     }
 }
 
-#[test]
-#[cfg_attr(miri, ignore)]
-fn test_random() {
-    test_perft_file::<Chess>("tests/random.perft", 10_000);
+// macro for generating tests
+macro_rules! gen_tests {
+    ($($fn_name:ident, $t:ty, $path:tt, $num:expr,)+) => {
+        $(
+			#[test]
+			#[cfg_attr(miri, ignore)]			
+			fn $fn_name() {
+				test_perft_file::<$t>($path, $num);
+			}
+		)+
+    }
 }
 
-#[test]
-#[cfg_attr(miri, ignore)]
-fn test_tricky() {
-    test_perft_file::<Chess>("tests/tricky.perft", 100_0000);
-}
-
-#[test]
-#[cfg_attr(miri, ignore)]
-fn test_atomic() {
-    test_perft_file::<Atomic>("tests/atomic.perft", 1_000_000);
-}
-
-#[test]
-#[cfg_attr(miri, ignore)]
-fn test_antichess() {
-    test_perft_file::<Antichess>("tests/antichess.perft", 1_000_000);
-}
-
-#[test]
-#[cfg_attr(miri, ignore)]
-fn test_crazyhouse() {
-    test_perft_file::<Crazyhouse>("tests/crazyhouse.perft", 1_000_000);
-}
-
-#[test]
-#[cfg_attr(miri, ignore)]
-fn test_racingkings() {
-    test_perft_file::<RacingKings>("tests/racingkings.perft", 1_000_000);
-}
-
-#[test]
-#[cfg_attr(miri, ignore)]
-fn test_horde() {
-    test_perft_file::<Horde>("tests/horde.perft", 1_000_000);
+// generate tests
+gen_tests! { 	
+	test_random,      Chess,       "tests/random.perft",         10_000 ,
+	test_tricky,      Chess,       "tests/tricky.perft",        100_000 ,
+	test_atomic,      Atomic,      "tests/atomic.perft",      1_000_000 ,
+	test_antichess,   Antichess,   "tests/antichess.perft",   1_000_000 ,
+	test_crazyhouse,  Crazyhouse,  "tests/crazyhouse.perft",  1_000_000 ,
+	test_racingkings, RacingKings, "tests/racingkings.perft", 1_000_000 ,
+	test_horde,       Horde,       "tests/horde.perft",       1_000_000 ,
 }


### PR DESCRIPTION
Code for tests in https://github.com/niklasf/shakmaty/blob/af4aa7a04532e61894fb787b3fd7700fe7de10ac/tests/perft.rs#L68 is repetitive, test functions only differ in type, path and node limit parameters.

This PR uses a macro to generate all tests for making the code more compact.

Tested.

```
running 7 tests
test test_antichess ... ok
test test_crazyhouse ... ok
test test_horde ... ok
test test_atomic ... ok
test test_racingkings ... ok
test test_tricky ... ok
test test_random ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 42.80s
```