### PR TITLE
Derive missing Eq, PartialEq, and Hash traits

### DIFF
--- a/src/fen.rs
+++ b/src/fen.rs
@@ -237,7 +237,7 @@ impl Default for FenOpts {
 }
 
 /// Errors that can occur when parsing a FEN.
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
 pub enum ParseFenError {
     InvalidFen,
     InvalidBoard,
@@ -358,7 +358,7 @@ impl fmt::Display for Board {
 }
 
 /// A parsed FEN.
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
 pub struct Fen {
     pub board: Board,
     pub pockets: Option<Material>,

--- a/src/position.rs
+++ b/src/position.rs
@@ -425,7 +425,7 @@ pub trait Position: Setup {
 }
 
 /// A standard Chess position.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Chess {
     board: Board,
     turn: Color,
@@ -677,7 +677,7 @@ pub(crate) mod variant {
     use crate::material::MaterialSide;
 
     /// An Atomic Chess position.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Eq, PartialEq, Hash)]
     pub struct Atomic {
         board: Board,
         turn: Color,
@@ -881,7 +881,7 @@ pub(crate) mod variant {
 
     /// An Antichess position. Antichess is also known as Giveaway, but players
     /// start without castling rights.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Eq, PartialEq, Hash)]
     pub struct Antichess {
         board: Board,
         turn: Color,
@@ -1023,7 +1023,7 @@ pub(crate) mod variant {
     }
 
     /// A King of the Hill position.
-    #[derive(Clone, Debug, Default)]
+    #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
     pub struct KingOfTheHill {
         chess: Chess,
     }
@@ -1110,7 +1110,7 @@ pub(crate) mod variant {
     }
 
     /// A Three-Check position.
-    #[derive(Clone, Debug, Default)]
+    #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
     pub struct ThreeCheck {
         chess: Chess,
         remaining_checks: ByColor<RemainingChecks>,
@@ -1209,7 +1209,7 @@ pub(crate) mod variant {
     }
 
     /// A Crazyhouse position.
-    #[derive(Clone, Debug, Default)]
+    #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
     pub struct Crazyhouse {
         chess: Chess,
         pockets: Material,
@@ -1377,7 +1377,7 @@ pub(crate) mod variant {
     }
 
     /// A Racing Kings position.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Eq, PartialEq, Hash)]
     pub struct RacingKings {
         board: Board,
         turn: Color,
@@ -1533,7 +1533,7 @@ pub(crate) mod variant {
     }
 
     /// A Horde position.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Eq, PartialEq, Hash)]
     pub struct Horde {
         board: Board,
         turn: Color,

--- a/src/position.rs
+++ b/src/position.rs
@@ -32,7 +32,7 @@ use crate::setup::{Castles, EpSquare, Setup, SwapTurn};
 use crate::movelist::MoveList;
 
 /// Outcome of a game.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum Outcome {
     Decisive { winner: Color },
     Draw,

--- a/src/san.rs
+++ b/src/san.rs
@@ -95,7 +95,7 @@ impl Error for ParseSanError {
 }
 
 /// `IllegalSan` or `AmbiguousSan`.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum SanError {
     /// Standard algebraic notation does not match a legal move.
     IllegalSan,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -201,7 +201,7 @@ impl<S: Setup> Setup for SwapTurn<S> {
 }
 
 /// Castling paths and unmoved rooks.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Castles {
     mask: Bitboard,
     rook: [[Option<Square>; 2]; 2],

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -363,7 +363,7 @@ impl Castles {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct EpSquare(pub Square);
 
 impl From<EpSquare> for Square {

--- a/src/types.rs
+++ b/src/types.rs
@@ -204,7 +204,7 @@ impl Piece {
 }
 
 /// Information about a move.
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
 #[repr(align(4))]
 pub enum Move {
     Normal {

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -98,7 +98,7 @@ impl Variant {
 ///
 /// [`Position`]: super::Position
 #[allow(missing_docs)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum VariantPosition {
     Chess(Chess),
     Atomic(Atomic),


### PR DESCRIPTION
### Motivation

1. The `Hash` trait allows for values to be collected into `HashSet`s and is thus convenient to derive on all types that can safely implement it, [in particular types that already derive `Eq` (and `PartialEq`)](https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq).
2. Since all types that implement `Setup` can be converted back and forth from `Fen`, which does implement `Eq` and `PartialEq` [and `Hash`], these traits can also be safely derived on chess variants to avoid the unnecessary conversion into `Fen` for the purpose of comparing for equality.