### PR TITLE
Implementation of insufficient material for Horde

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -1684,9 +1684,215 @@ pub(crate) mod variant {
                 return false;
             }
 
-            // TODO: Detect when the horde can not mate. Note that it does not have
-            // a king.
-            false
+            // By this point: color == White
+            let horde = self.board.material_side(color);
+            let horde_darkb = (Bitboard::DARK_SQUARES & self.board.by_color(color) & self.board.bishops()).count() as u8;
+            let horde_lightb = (Bitboard::LIGHT_SQUARES & self.board.by_color(color) & self.board.bishops()).count() as u8;
+            let horde_bishop_co = || { if horde_lightb >= 1 {White} else {Black} };
+            let horde_num =
+                horde.pawns + horde.knights + horde.rooks + horde.queens +
+                if horde_darkb <= 2 {horde_darkb} else {2} +
+                if horde_lightb <= 2 {horde_lightb} else {2};
+                // Two same color bishops suffice to cover all the light and dark squares
+                // around the enemy king.
+
+            let pieces = self.board.material_side(!color);
+            let pieces_darkb = || -> u8 { (Bitboard::DARK_SQUARES & self.board.by_color(!color) & self.board.bishops()).count() as u8 };
+            let pieces_lightb = || -> u8 { (Bitboard::LIGHT_SQUARES & self.board.by_color(!color) & self.board.bishops()).count() as u8 };
+            let pieces_num = pieces.count() as u8;
+            let pieces_oppositeb_of = | square_color: Color | -> u8 {
+                match square_color {
+                    White => pieces_darkb(),
+                    Black => pieces_lightb(),
+                }
+            };
+            let pieces_sameb_as = | square_color: Color | -> u8 {
+                match square_color {
+                    White => pieces_lightb(),
+                    Black => pieces_darkb(),
+                }
+            };
+            let pieces_of_type_not = | piece: u8 | -> u8 {
+                pieces_num - piece
+            };
+            let has_bishop_pair = | side: Color | -> bool {
+                match side {
+                    White => horde_lightb >= 1 && horde_darkb >= 1,
+                    Black => pieces_lightb() >= 1 && pieces_darkb() >= 1,
+                }
+            };
+
+            if horde_num == 0 {
+                return true;
+            }
+            if horde_num >= 4 {
+                // Four or more white pieces can always deliver mate.
+                return false;
+            }
+            if (horde.pawns >= 1 || horde.queens >= 1) && horde_num >= 2 {
+                // Pawns/queens are never insufficient material when paired with any other
+                // piece (a pawn promotes to a queen and delivers mate).
+                return false;
+            }
+            if horde.rooks >= 1  && horde_num >= 2 {
+                // A rook is insufficient material only when it is paired with a bishop
+                // against a lone king. The horde can mate in any other case.
+                // A rook on A1 and a bishop on C3 mate a king on B1 when there is a
+                // friendly pawn/opposite-color-bishop/rook/queen on C2.
+                // A rook on B8 and a bishop C3 mate a king on A1 when there is a friendly
+                // knight on A2.
+                if !(horde_num == 2 && horde.rooks == 1 && horde.bishops == 1 && pieces_of_type_not(pieces_sameb_as(horde_bishop_co())) == 1) {
+                    return false;
+                }
+            }
+
+            if horde_num == 1 {
+                if pieces_num == 1 {
+                    // A lone piece cannot mate a lone king.
+                    return true;
+                } else if horde.queens == 1 {
+                    // The horde has a lone queen.
+                    // A lone queen mates a king on A1 bounded by:
+                    //  -- a pawn/rook on A2
+                    //  -- two same color bishops on A2, B1
+                    // We ignore every other mating case, since it can be reduced to
+                    // the two previous cases (e.g. a black pawn on A2 and a black
+                    // bishop on B1).
+                    return !(
+                            pieces.pawns >= 1 ||
+                            pieces.rooks >= 1 ||
+                            pieces_lightb() >= 2 ||
+                            pieces_darkb() >= 2
+                            );
+                } else if horde.pawns == 1 {
+                    // Promote the pawn to a queen or a knight and check whether white
+                    // can mate.
+                    let pawn_square = (self.board.pawns() & self.board.by_color(color)).single_square().unwrap();
+                    let mut promote_to_queen = self.clone();
+                    promote_to_queen.board.set_piece_at(pawn_square, color.queen(), true);
+                    let mut promote_to_knight = self.clone();
+                    promote_to_knight.board.set_piece_at(pawn_square, color.knight(), true);
+                    return promote_to_queen.has_insufficient_material(color) && promote_to_knight.has_insufficient_material(color);
+                } else if horde.rooks == 1 {
+                    // A lone rook mates a king on A8 bounded by a pawn/rook on A7 and a
+                    // pawn/knight on B7. We ignore every other case, since it can be
+                    // reduced to the two previous cases.
+                    // (e.g. three pawns on A7, B7, C7)
+                    return !(
+                        pieces.pawns >= 2 ||
+                        (pieces.rooks >= 1 && pieces.pawns >= 1) ||
+                        (pieces.rooks >= 1 && pieces.knights >= 1) ||
+                        (pieces.pawns >= 1 && pieces.knights >= 1)
+                        );
+                } else if horde.bishops == 1 {
+                    // The horde has a lone bishop.
+                    return !(
+                            // The king can be mated on A1 if there is a pawn/opposite-color-bishop
+                            // on A2 and an opposite-color-bishop on B1.
+                            // If black has two or more pawns, white gets the benefit of the doubt;
+                            // there is an outside chance that white promotes its pawns to
+                            // opposite-color-bishops and selfmates theirself.
+                            // Every other case that the king is mated by the bishop requires that
+                            // black has two pawns or two opposite-color-bishop or a pawn and an
+                            // opposite-color-bishop.
+                            // For example a king on A3 can be mated if there is
+                            // a pawn/opposite-color-bishop on A4, a pawn/opposite-color-bishop on
+                            // B3, a pawn/bishop/rook/queen on A2 and any other piece on B2.
+                            pieces_oppositeb_of(horde_bishop_co()) >= 2 ||
+                            (pieces_oppositeb_of(horde_bishop_co()) >= 1 && pieces.pawns >= 1) ||
+                            pieces.pawns >= 2
+                        );
+                } else if horde.knights == 1 {
+                    // The horde has a lone knight.
+                    return !(
+                            // The king on A1 can be smother mated by a knight on C2 if there is
+                            // a pawn/knight/bishop on B2, a knight/rook on B1 and any other piece
+                            // on A2.
+                            // Moreover, when black has four or more pieces and two of them are
+                            // pawns, black can promote their pawns and selfmate theirself.
+                            pieces_num >= 4 && (
+                                pieces.knights>=2 || pieces.pawns>=2 ||
+                                (pieces.rooks>=1 && pieces.knights>=1) ||
+                                (pieces.rooks>=1 && pieces.bishops>=1) ||
+                                (pieces.knights>=1 && pieces.bishops>=1) ||
+                                (pieces.rooks>=1 && pieces.pawns>=1) ||
+                                (pieces.knights>=1 && pieces.pawns>=1) ||
+                                (pieces.bishops>=1 && pieces.pawns>=1) ||
+                                (has_bishop_pair(!color) && pieces.pawns>=1)
+                            ) && if pieces_darkb()>=2 {pieces_of_type_not(pieces_darkb())>=3} else {true}
+                            && if pieces_lightb()>=2 {pieces_of_type_not(pieces_lightb())>=3} else {true}
+                        );
+                }
+
+        // By this point, we only need to deal with white's minor pieces.
+
+            } else if horde_num == 2 {
+
+                if pieces_num == 1 {
+                    // Two minor pieces cannot mate a lone king.
+                    return true;
+                } else if horde.knights == 2 {
+                    // A king on A1 is mated by two knights, if it is obstructed by a
+                    // pawn/bishop/knight on B2. On the other hand, if black only has
+                    // major pieces it is a draw.
+                    return !(pieces.pawns + pieces.bishops + pieces.knights >= 1);
+                } else if has_bishop_pair(color) {
+                    return !(
+                            // A king on A1 obstructed by a pawn/bishop on A2 is mated
+                            // by the bishop pair.
+                            pieces.pawns >= 1 || pieces.bishops >= 1 ||
+                            // A pawn/bishop/knight on B4, a pawn/bishop/rook/queen on
+                            // A4 and the king on A3 enable Boden's mate by the bishop
+                            // pair. In every other case white cannot win.
+                            ( pieces.knights >= 1 && pieces.rooks + pieces.queens >= 1 )
+                            );
+                } else if horde.bishops >= 1 && horde.knights >= 1 {
+                    // The horde has a bishop and a knight.
+                    return !(
+                            // A king on A1 obstructed by a pawn/opposite-color-bishop on
+                            // A2 is mated by a knight on D2 and a bishop on C3.
+                            pieces.pawns >= 1 || pieces_oppositeb_of(horde_bishop_co()) >= 1 ||
+                            // A king on A1 bounded by two friendly pieces on A2 and B1 is
+                            // mated when the knight moves from D4 to C2 so that both the
+                            // knight and the bishop deliver check.
+                            pieces_of_type_not( pieces_sameb_as(horde_bishop_co()) ) >=3
+                            );
+                } else {
+                    // The horde has two or more bishops on the same color.
+                    // White can only win if black has enough material to obstruct
+                    // the squares of the opposite color around the king.
+                    return !(
+                            // A king on A1 obstructed by a pawn/opposite-bishop/knight
+                            // on A2 and a opposite-bishop/knight on B1 is mated by two
+                            // bishops on B2 and C3. This position is theoretically
+                            // achievable even when black has two pawns or when they
+                            // have a pawn and an opposite color bishop.
+                            ( pieces.pawns >= 1 && pieces_oppositeb_of(horde_bishop_co()) >= 1 ) ||
+                            ( pieces.pawns >= 1 && pieces.knights >= 1 ) ||
+                            ( pieces_oppositeb_of(horde_bishop_co()) >= 1 && pieces.knights >= 1 ) ||
+                            ( pieces_oppositeb_of(horde_bishop_co()) >= 2 ) ||
+                            pieces.knights >= 2 ||
+                            pieces.pawns >= 2
+                            // In every other case, white can only draw.
+                            );
+                }
+
+            } else if horde_num == 3 {
+                // A king in the corner is mated by two knights and a bishop or three
+                // knights or the bishop pair and a knight/bishop.
+                if (horde.knights == 2 && horde.bishops == 1) || horde.knights == 3 || has_bishop_pair(color) {
+                    return false;
+                } else {
+                    // White has two same color bishops and a knight.
+                    // A king on A1 is mated by a bishop on B2, a bishop on C1 and a
+                    // knight on C3, as long as there is another black piece to waste
+                    // a tempo.
+                    return pieces_num == 1;
+                }
+            }
+
+            return true
+
         }
 
         fn variant_outcome(&self) -> Option<Outcome> {
@@ -2230,7 +2436,7 @@ mod tests {
         assert_insufficient_material::<Crazyhouse>("8/5k2/8/8/8/5B2/3KB3/8 w - - 0 1", false, false);
         assert_insufficient_material::<Crazyhouse>("8/8/8/8/3k4/3N~4/3K4/8 w - - 0 1", false, false);
 
-        assert_insufficient_material::<Horde>("8/5k2/8/8/8/4NN2/8/8 w - - 0 1", false_negative, false);
+        assert_insufficient_material::<Horde>("8/5k2/8/8/8/4NN2/8/8 w - - 0 1", true, false);
     }
 
     #[cfg(feature = "variant")]

--- a/tests/horde_white_insufficient_material.rs
+++ b/tests/horde_white_insufficient_material.rs
@@ -1,0 +1,56 @@
+#[cfg(feature = "variant")]
+#[test]
+fn white_insufficient_material_in_horde() {
+    use shakmaty::{CastlingMode,Position};
+    use shakmaty::variant::Horde;
+    use shakmaty::fen::Fen;
+    use shakmaty::Color;
+    use shakmaty::FromSetup;
+
+    use std::io::BufReader;
+    use std::io::prelude::*;
+    use std::fs::File;
+
+
+    fn assert_white_insufficient_material_in_horde<P>(fen: &str, expected_outcome:bool, comment: &str)
+    where
+        P: Position + FromSetup,
+    {
+        let pos: P = fen.parse::<Fen>()
+            .expect("valid fen")
+            .position(CastlingMode::Chess960)
+            .expect("valid position");
+
+        let has_insufficient_material = pos.has_insufficient_material(Color::White);
+
+        assert_eq!(
+            has_insufficient_material,
+            expected_outcome,
+            "
+\n
+{:?}\n
+{:?}
+{:?}\n
+computed_outcome={:?}
+expected_outcome={:?}\n\n",
+            comment,pos.board(),fen,has_insufficient_material,expected_outcome
+        );
+    }
+
+
+	let file = File::open("tests/horde_white_insufficient_material_tests").expect("failed to open test suite");
+	let reader = BufReader::new(file);
+	let mut current;
+
+	for line in reader.lines() {
+		current = line.unwrap();
+		let fen_expected_comment: Vec<&str> = current.split(',').collect();
+
+		assert_white_insufficient_material_in_horde::<Horde>(
+			fen_expected_comment[0],
+			if fen_expected_comment[1]=="true" {true} else {false},
+			fen_expected_comment[2]
+		);
+	}
+
+}


### PR DESCRIPTION
Hey, there

This pull request implements the insufficient material method for Horde.

First we need to determine the horde checkmating patterns that use the least amount of material. 
That is fairly easy to do in positions where white has queens, rooks and pawns or when white has more than three pieces; for example a queen and any other white piece mate the black king, pawns promote to queens or knights, etc.

Positions with minor pieces are a bit trickier, since they're more of them and a bishop and a knight can deliver a double check. But even those can be worked out by hand. Then we can use a brute force approach to validate that we haven't missed out any of them, similarly to how endgame tablebases are generated.  

We quantify those patterns into conditions that can be used to check any given position against at run time. 

[Here](https://github.com/stevepapazis/horde-insufficient-material-tests) is a little more information on horde checkmating patterns and generation of test positions. 