### PR TITLE
Implement `Eq` for `Chess`.

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -348,7 +348,7 @@ impl FromIterator<(Square, Piece)> for Board {
 }
 
 /// Iterator over the pieces of a [`Board`].
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Pieces {
     pawns: Bitboard,
     knights: Bitboard,

--- a/src/position.rs
+++ b/src/position.rs
@@ -493,6 +493,47 @@ impl Default for Chess {
     }
 }
 
+
+impl PartialEq for Chess {
+    fn eq(&self, other: &Self) -> bool {
+        self.board == other.board &&
+        self.turn == other.turn &&
+        // tricky part, see https://github.com/niklasf/shakmaty/pull/37#issuecomment-793052003
+        // "For example, Castles instances can be distinct due to the path field, even when no castling rights remain. 
+        // The corresponding positions would be semantically equal (but not structurally) and have the same FEN."
+
+        // We intentionally do not check for the castling mode.
+        self.castling_rights() == other.castling_rights() &&
+        self.ep_square == other.ep_square &&
+        self.halfmoves == other.halfmoves &&
+        self.fullmoves == other.fullmoves
+    }
+}
+
+/// Equivalent to comparing the [`fen()`](crate::fen::fen()) of both positions, but much faster.
+///
+/// # Example
+///
+/// It means positions with the same castling rights are equals even though they don't have
+/// the same [`CastlingMode`].
+/// ```
+/// # use std::error::Error;
+/// # use shakmaty::Chess;
+/// use shakmaty::fen::{Fen, fen};
+/// use shakmaty::{CastlingMode};
+///
+/// let input = "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4";
+/// let setup: Fen = input.parse()?;
+/// let position: Chess = setup.position(CastlingMode::Standard)?;
+/// let position_960: Chess = setup.position(CastlingMode::Chess960)?;
+/// assert_eq!(fen(&position), fen(&position_960));
+/// assert_eq!(position, position_960);
+/// #
+/// # Ok::<_, Box<dyn Error>>(())
+/// ```
+
+impl Eq for Chess {}
+
 impl Setup for Chess {
     fn board(&self) -> &Board { &self.board }
     fn pockets(&self) -> Option<&Material> { None }
@@ -2364,24 +2405,23 @@ mod tests {
 
     struct _AssertObjectSafe(Box<dyn Position>);
 
+    // from fen
+    fn ffen<T: Position + FromSetup>(fen: &str) -> T {
+        fen.parse::<Fen>()
+            .expect("valid fen")
+            .position::<T>(CastlingMode::Chess960)
+            .expect("legal position")
+    }
+
     #[test]
     fn test_most_known_legals() {
-        let fen = "R6R/3Q4/1Q4Q1/4Q3/2Q4Q/Q4Q2/pp1Q4/kBNN1KB1 w - - 0 1";
-        let pos: Chess = fen.parse::<Fen>()
-            .expect("valid fen")
-            .position(CastlingMode::Chess960)
-            .expect("legal position");
-
+        let pos: Chess = ffen("R6R/3Q4/1Q4Q1/4Q3/2Q4Q/Q4Q2/pp1Q4/kBNN1KB1 w - - 0 1");
         assert_eq!(pos.legal_moves().len(), 218);
     }
 
     #[test]
     fn test_pinned_san_candidate() {
-        let fen = "R2r2k1/6pp/1Np2p2/1p2pP2/4p3/4K3/3r2PP/8 b - - 5 37";
-        let pos: Chess = fen.parse::<Fen>()
-            .expect("valid fen")
-            .position(CastlingMode::Chess960)
-            .expect("valid position");
+        let pos: Chess = ffen("R2r2k1/6pp/1Np2p2/1p2pP2/4p3/4K3/3r2PP/8 b - - 5 37");
 
         let moves = pos.san_candidates(Role::Rook, Square::D3);
 
@@ -2398,11 +2438,7 @@ mod tests {
 
     #[test]
     fn test_promotion() {
-        let fen = "3r3K/6PP/8/8/8/2k5/8/8 w - - 0 1";
-        let pos: Chess = fen.parse::<Fen>()
-            .expect("valid fen")
-            .position(CastlingMode::Chess960)
-            .expect("valid position");
+        let pos: Chess = ffen("3r3K/6PP/8/8/8/2k5/8/8 w - - 0 1");
 
         let moves = pos.legal_moves();
         assert!(moves.iter().all(|m| m.role() == Role::Pawn));
@@ -2413,10 +2449,7 @@ mod tests {
     where
         P: Position + FromSetup,
     {
-        let pos: P = fen.parse::<Fen>()
-            .expect("valid fen")
-            .position(CastlingMode::Chess960)
-            .expect("valid position");
+        let pos: P = ffen(fen);
 
         assert_eq!(pos.has_insufficient_material(White), white);
         assert_eq!(pos.has_insufficient_material(Black), black);
@@ -2434,6 +2467,33 @@ mod tests {
         assert_insufficient_material::<Chess>("5K2/8/8/1B6/8/k7/6b1/8 w - - 0 39", true, true);
         assert_insufficient_material::<Chess>("8/8/8/4k3/5b2/3K4/8/2B5 w - - 0 33", true, true);
         assert_insufficient_material::<Chess>("3b4/8/8/6b1/8/8/R7/K1k5 w - - 0 1", false, true);
+    }
+
+    #[test]
+    fn test_eq() {
+        fn assert_pos(left: Chess, right: Chess, check_equal: bool) {
+            if check_equal {
+            assert_eq!(left, right);
+            assert_eq!(fen(&left), fen(&right));
+            } else {
+            assert_ne!(left, right);
+            assert_ne!(fen(&left), fen(&right));         
+            }
+        }
+        fn assert_eq(left: Chess, right: Chess) {assert_pos(left, right, true)}
+        fn assert_ne(left: Chess, right: Chess) {assert_pos(left, right, false)}
+        assert_eq(Chess::default(), Chess::default());
+        assert_ne(Chess::default(), Chess::default().swap_turn().expect("swap turn legal"));
+        // check if `Castles.paths` do not interfere.
+        let pos: Chess = ffen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBK1BNR w KQkq - 0 1");
+        let pos_after_move = pos.play(&Move::Normal { // breaks white castling
+            role: Role::King,
+            from: Square::D1,
+            to: Square::E1,
+            capture: None,
+            promotion: None,
+        }).expect("Ke1 is legal");
+        assert_eq(pos_after_move, ffen::<Chess>("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB1KBNR b kq - 1 1"))
     }
 
     #[cfg(feature = "variant")]
@@ -2478,10 +2538,7 @@ mod tests {
     fn test_exploded_king_loses_castling_rights() {
         use super::variant::Atomic;
 
-        let pos: Atomic = "rnb1kbnr/pppppppp/8/4q3/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1".parse::<Fen>()
-            .expect("valid fen")
-            .position(CastlingMode::Chess960)
-            .expect("valid position");
+        let pos: Atomic = ffen("rnb1kbnr/pppppppp/8/4q3/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1");
 
         let pos = pos.play(&Move::Normal {
             role: Role::Queen,
@@ -2504,34 +2561,21 @@ mod tests {
         use super::variant::RacingKings;
 
         // Both players reached the backrank.
-        let pos: RacingKings = "kr3NK1/1q2R3/8/8/8/5n2/2N5/1rb2B1R w - - 11 14".parse::<Fen>()
-            .expect("valid fen")
-            .position(CastlingMode::Chess960)
-            .expect("valid position");
+        let pos: RacingKings = ffen("kr3NK1/1q2R3/8/8/8/5n2/2N5/1rb2B1R w - - 11 14");
         assert!(pos.is_variant_end());
         assert_eq!(pos.variant_outcome(), Some(Outcome::Draw));
 
         // White to move is lost because black reached the backrank.
-        let pos: RacingKings = "1k6/6K1/8/8/8/8/8/8 w - - 0 1".parse::<Fen>()
-            .expect("valid fen")
-            .position(CastlingMode::Chess960)
-            .expect("valid position");
+        let pos: RacingKings = ffen("1k6/6K1/8/8/8/8/8/8 w - - 0 1");
         assert!(pos.is_variant_end());
         assert_eq!(pos.variant_outcome(), Some(Outcome::Decisive { winner: Color::Black }));
 
         // Black is given a chance to catch up.
-        let pos: RacingKings = "1K6/7k/8/8/8/8/8/8 b - - 0 1".parse::<Fen>()
-            .expect("valid fen")
-            .position(CastlingMode::Chess960)
-            .expect("valid position");
-        assert!(!pos.is_variant_end());
+        let pos: RacingKings = ffen("1K6/7k/8/8/8/8/8/8 b - - 0 1");
         assert_eq!(pos.variant_outcome(), None);
 
         // Black near backrank but cannot move there.
-        let pos: RacingKings = "2KR4/k7/2Q5/4q3/8/8/8/2N5 b - - 0 1".parse::<Fen>()
-            .expect("valid fen")
-            .position(CastlingMode::Chess960)
-            .expect("valid position");
+        let pos: RacingKings = ffen("2KR4/k7/2Q5/4q3/8/8/8/2N5 b - - 0 1");
         assert!(pos.is_variant_end());
         assert_eq!(pos.variant_outcome(), Some(Outcome::Decisive { winner: Color::White }));
     }

--- a/src/position.rs
+++ b/src/position.rs
@@ -496,7 +496,8 @@ impl Default for Chess {
 
 impl PartialEq for Chess {
     fn eq(&self, other: &Self) -> bool {
-        self.board == other.board &&
+        // We disregard the `promoted` bitboard
+        self.board.pieces() == other.board.pieces() &&
         self.turn == other.turn &&
         // tricky part, see https://github.com/niklasf/shakmaty/pull/37#issuecomment-793052003
         // "For example, Castles instances can be distinct due to the path field, even when no castling rights remain. 
@@ -2493,7 +2494,27 @@ mod tests {
             capture: None,
             promotion: None,
         }).expect("Ke1 is legal");
-        assert_eq(pos_after_move, ffen::<Chess>("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB1KBNR b kq - 1 1"))
+        assert_eq(pos_after_move, ffen::<Chess>("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB1KBNR b kq - 1 1"));
+        // check if `board.promoted` does not interfere.
+        let pos2: Chess = ffen("rnbqkbn1/pppppppP/8/8/8/8/PPPPPPP1/RNBQKBNR w KQq - 0 26");
+        let pos2_after_promotion_Q = pos2.clone().play(&Move::Normal {
+            role: Role::Pawn,
+            from: Square::H7,
+            to: Square::H8,
+            capture: None,
+            promotion: Some(Role::Queen),
+        }).expect("h8=Q is legal");
+        let pos2_after_promotion_N = pos2.play(&Move::Normal {
+            role: Role::Pawn,
+            from: Square::H7,
+            to: Square::H8,
+            capture: None,
+            promotion: Some(Role::Knight),
+        }).expect("h8=N is legal");
+        let final_pos: Chess = ffen("rnbqkbnQ/ppppppp1/8/8/8/8/PPPPPPP1/RNBQKBNR b KQq - 0 26");
+        assert_eq(pos2_after_promotion_Q, final_pos.clone());
+        assert_ne(pos2_after_promotion_N, final_pos);
+
     }
 
     #[cfg(feature = "variant")]


### PR DESCRIPTION
Completely equivalent to `Fen::fen(Chess)`, i.e not checking `CastlingMode`. This behavior is up to debate.
Address https://github.com/niklasf/shakmaty/pull/37#issuecomment-793052003.

Did not implement `Hash` for now, because it could either similar to the `Eq` implementation or be `Zobrist` based.