### PR TITLE
update `legal_moves` doc string.

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -297,7 +297,7 @@ pub trait FromSetup: Sized {
 /// A legal chess or chess variant position. See [`Chess`] for a concrete
 /// implementation. Extends [`Setup`].
 pub trait Position: Setup {
-    /// Collects all legal moves in an existing buffer.
+    /// Generate all legal moves.
     fn legal_moves(&self) -> MoveList;
 
     /// Generates a subset of legal moves: All piece moves and drops of type


### PR DESCRIPTION
After the breaking change of `v0.18.0`.