### PR TITLE
Implement `Copy` for `ByRole` and `ByColor` when possible

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -179,7 +179,7 @@ impl FromStr for Color {
 }
 
 /// Container with values for each [`Color`].
-#[derive(Clone, Default, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Debug, Hash)]
 #[repr(C)]
 pub struct ByColor<T> {
     pub black: T,

--- a/src/role.rs
+++ b/src/role.rs
@@ -186,7 +186,7 @@ macro_rules! try_role_from_int_impl {
 try_role_from_int_impl! { u8 i8 u16 i16 u32 i32 u64 i64 usize isize }
 
 /// Container with values for each [`Role`].
-#[derive(Clone, Default, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Debug, Hash)]
 #[repr(C)]
 pub struct ByRole<T> {
     pub pawn: T,


### PR DESCRIPTION
These two structs are basically named containers and copying them when the values stored can be is practical.

I am not familiar with `repr(C)` though, so there might be reasons why it was not made in the first place.