### PR TITLE
Optimise `Position::outcome`

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -558,7 +558,7 @@ pub trait Position {
     /// [insufficient material](Position::is_insufficient_material) or
     /// [variant end](Position::is_variant_end).
     fn is_game_over(&self) -> bool {
-        self.legal_moves().is_empty() || self.is_insufficient_material()
+        self.is_variant_end() || self.legal_moves().is_empty() || self.is_insufficient_material()
     }
 
     /// The outcome of the game, or `None` if the game is not over.


### PR DESCRIPTION
Previously `legal_moves` which is costly was called twice, by `self.is_checkmate()` and `self.is_stalemate()`.

Did some basic testing, tell me if you want more