### PR TITLE
feat!: allow usage in `no_std` environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,19 @@ jobs:
         docs:
           - ""
           - "--features variant"
+        include:
+          - toolchain: "nightly"
+            features: "--features step"
+          - toolchain: "nightly"
+            features: "--features alloc,step"
+          - toolchain: "nightly"
+            features: "--features std,step"
+          - toolchain: "nightly"
+            features: "--features step,variant"
+          - toolchain: "nightly"
+            features: "--features alloc,step,variant"
+          - toolchain: "nightly"
+            features: "--features std,step,variant"
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get update && sudo apt-get install -y valgrind

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
           - "--features alloc,variant"
           - "--features std"
           - "--features std,variant"
+        docs:
+          - ""
+          - "--features variant"
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get update && sudo apt-get install -y valgrind
@@ -36,7 +39,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --no-default-features ${{ matrix.features }}
+          args: ${{ matrix.docs }}
       - uses: actions-rs/cargo@v1
         with:
           command: bench

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,6 @@ jobs:
           - "--features alloc,variant"
           - "--features std,variant"
         include:
-          - semver: ""
-          - toolchain: "nightly"
-            semver: "-Z minimal-versions"
           - toolchain: "nightly"
             features: "--features step"
           - toolchain: "nightly"
@@ -36,6 +33,7 @@ jobs:
             features: "--features alloc,step,variant"
           - toolchain: "nightly"
             features: "--features std,step,variant"
+          - toolchain: "nightly"
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get update && sudo apt-get install -y valgrind
@@ -48,7 +46,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.semver }} --no-default-features ${{ matrix.features }}
+          args: --no-default-features ${{ matrix.features }}
       - uses: actions-rs/cargo@v1
         with:
           command: bench
@@ -72,3 +70,31 @@ jobs:
         with:
           command: doc
           args: ${{ matrix.docs }}
+  semver:
+    strategy:
+      matrix:
+        features:
+          - ""
+          - "--features variant"
+          - "--features alloc"
+          - "--features std"
+          - "--features alloc,variant"
+          - "--features std,variant"
+          - "--features step"
+          - "--features alloc,step"
+          - "--features std,step"
+          - "--features step,variant"
+          - "--features alloc,step,variant"
+          - "--features std,step,variant"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -Z minimal-versions ${{ matrix.features }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,25 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  - push
+  - pull_request
 
 jobs:
   test:
     strategy:
       matrix:
-        toolchain: ["1.60.0", "stable", "beta", "nightly"]
+        toolchain:
+          - "1.60.0"
+          - "stable"
+          - "beta"
+          - "nightly"
+        features:
+          - ""
+          - "--features variant"
+          - "--features alloc"
+          - "--features alloc,variant"
+          - "--features std"
+          - "--features std,variant"
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get update && sudo apt-get install -y valgrind
@@ -19,17 +32,11 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features variant
+          args: --no-default-features ${{ matrix.features }}
       - uses: actions-rs/cargo@v1
         with:
           command: doc
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --features variant
+          args: --no-default-features ${{ matrix.features }}
       - uses: actions-rs/cargo@v1
         with:
           command: bench
@@ -45,8 +52,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -Z minimal-versions
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -Z minimal-versions --features variant
+          args: -Z minimal-versions --no-default-features ${{ matrix.features }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,13 @@ jobs:
           - ""
           - "--features variant"
           - "--features alloc"
-          - "--features alloc,variant"
           - "--features std"
+          - "--features alloc,variant"
           - "--features std,variant"
-        docs:
-          - ""
-          - "--features step"
-          - "--features variant"
-          - "--features step,variant"
         include:
+          - semver: ""
+          - toolchain: "nightly"
+            semver: "-Z minimal-versions"
           - toolchain: "nightly"
             features: "--features step"
           - toolchain: "nightly"
@@ -50,11 +48,18 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features ${{ matrix.features }}
+          args: ${{ matrix.semver }} --no-default-features ${{ matrix.features }}
       - uses: actions-rs/cargo@v1
         with:
           command: bench
   docs:
+    strategy:
+      matrix:
+        docs:
+          - ""
+          - "--features step"
+          - "--features variant"
+          - "--features step,variant"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -67,16 +72,3 @@ jobs:
         with:
           command: doc
           args: ${{ matrix.docs }}
-  semver:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -Z minimal-versions --no-default-features ${{ matrix.features }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,9 @@ jobs:
           - "--features std,variant"
         docs:
           - ""
+          - "--features step"
           - "--features variant"
+          - "--features step,variant"
         include:
           - toolchain: "nightly"
             features: "--features step"
@@ -51,11 +53,20 @@ jobs:
           args: --no-default-features ${{ matrix.features }}
       - uses: actions-rs/cargo@v1
         with:
-          command: doc
-          args: ${{ matrix.docs }}
+          command: bench
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: bench
+          command: doc
+          args: ${{ matrix.docs }}
   semver:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ edition = "2021"
 rust-version = "1.60"
 
 [features]
-default = []
+default = ["std"]
+alloc = []
+std = ["alloc"]
 step = []
 variant = []
 
@@ -27,7 +29,7 @@ bench = false
 [dependencies]
 bitflags = "1.0.4"
 btoi = "0.4"
-arrayvec = "0.7"
+arrayvec = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 iai = "0.1"

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -16,7 +16,7 @@
 
 //! Sets of squares.
 
-use std::{
+use core::{
     fmt,
     fmt::Write,
     iter::{FromIterator, FusedIterator},
@@ -1112,15 +1112,18 @@ impl FusedIterator for CarryRippler {}
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "alloc")]
+    use alloc::format;
+
     use super::*;
 
     #[test]
     fn test_more_than_one() {
-        assert_eq!(Bitboard(0).more_than_one(), false);
-        assert_eq!(Bitboard(1).more_than_one(), false);
-        assert_eq!(Bitboard(2).more_than_one(), false);
-        assert_eq!(Bitboard(3).more_than_one(), true);
-        assert_eq!(Bitboard::FULL.more_than_one(), true);
+        assert!(!Bitboard(0).more_than_one());
+        assert!(!Bitboard(1).more_than_one());
+        assert!(!Bitboard(2).more_than_one());
+        assert!(Bitboard(3).more_than_one());
+        assert!(Bitboard::FULL.more_than_one());
     }
 
     #[test]
@@ -1160,21 +1163,25 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_upper_hex() {
         assert_eq!(format!("{:#0X}", Bitboard(42)), format!("{:#0X}", 42));
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_lower_hex() {
         assert_eq!(format!("{:#0x}", Bitboard(42)), format!("{:#0x}", 42));
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_octal() {
         assert_eq!(format!("{:#0o}", Bitboard(42)), format!("{:#0o}", 42));
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_binary() {
         assert_eq!(format!("{:#0b}", Bitboard(42)), format!("{:#0b}", 42));

--- a/src/board.rs
+++ b/src/board.rs
@@ -16,7 +16,7 @@
 
 //! Piece positions on a board.
 
-use std::{
+use core::{
     fmt,
     fmt::Write,
     iter::{FromIterator, FusedIterator},

--- a/src/color.rs
+++ b/src/color.rs
@@ -16,7 +16,7 @@
 
 //! White or black.
 
-use std::{array, convert::identity, error::Error, fmt, mem, ops, str::FromStr};
+use core::{array, convert::identity, fmt, mem, ops, str::FromStr};
 
 use crate::{
     role::{ByRole, Role},
@@ -168,7 +168,8 @@ impl fmt::Display for ParseColorError {
     }
 }
 
-impl Error for ParseColorError {}
+#[cfg(feature = "std")]
+impl std::error::Error for ParseColorError {}
 
 impl FromStr for Color {
     type Err = ParseColorError;

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -38,11 +38,10 @@
 //! ```
 //! use shakmaty::{fen::Fen, CastlingMode, Chess, Position};
 //!
-//! let fen: Fen = "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4".parse()?;
-//!
-//! let pos: Chess = fen.into_position(CastlingMode::Standard)?;
+//! const FEN: &str =  "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4";
+//! let fen: Fen = FEN.parse().unwrap();
+//! let pos: Chess = fen.into_position(CastlingMode::Standard).unwrap();
 //! assert!(pos.is_checkmate());
-//! # Ok::<_, Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! # Writing
@@ -375,9 +374,9 @@ impl Fen {
     /// ```
     /// use shakmaty::fen::Fen;
     ///
-    /// let fen = Fen::from_ascii(b"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")?;
+    /// const FEN: &[u8] = b"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+    /// let fen = Fen::from_ascii(FEN).unwrap();
     /// assert_eq!(fen, Fen::default());
-    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn from_ascii(fen: &[u8]) -> Result<Fen, ParseFenError> {
         let mut result = Setup::empty();

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -87,7 +87,9 @@ fn fmt_castling(
     let mut empty = true;
 
     for color in Color::ALL {
-        let king = board.king_of(color).filter(|k| k.rank() == color.backrank());
+        let king = board
+            .king_of(color)
+            .filter(|k| k.rank() == color.backrank());
 
         let candidates = board.by_piece(color.rook()) & color.backrank();
 
@@ -629,7 +631,6 @@ impl Display for Epd {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Chess, EnPassantMode, Position};
 
     #[cfg(feature = "alloc")]
     #[test]
@@ -642,7 +643,7 @@ mod tests {
         );
 
         // The en passant square is not actually legal.
-        let pos: Chess = fen
+        let pos: crate::Chess = fen
             .into_position(CastlingMode::Standard)
             .expect("legal position");
         assert_eq!(pos.maybe_ep_square(), Some(Square::D3));

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -61,16 +61,18 @@
 //!            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -");
 //! ```
 
-use std::{
+use core::{
     char,
     cmp::max,
     convert::TryFrom,
-    error::Error,
     fmt,
     fmt::{Display, Write as _},
     num::NonZeroU32,
     str::FromStr,
 };
+
+#[cfg(feature = "alloc")]
+use alloc::string::{String, ToString};
 
 use crate::{
     Bitboard, Board, ByColor, ByRole, CastlingMode, Color, EnPassantMode, File, FromSetup, Piece,
@@ -175,7 +177,8 @@ impl Display for ParseFenError {
     }
 }
 
-impl Error for ParseFenError {}
+#[cfg(feature = "std")]
+impl std::error::Error for ParseFenError {}
 
 fn parse_board_fen(board_fen: &[u8]) -> Result<(Board, Bitboard), ParseFenError> {
     let mut promoted = Bitboard(0);
@@ -628,6 +631,7 @@ mod tests {
     use super::*;
     use crate::{Chess, EnPassantMode, Position};
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_legal_ep_square() {
         let original_epd = "4k3/8/8/8/3Pp3/8/8/3KR3 b - d3";
@@ -748,6 +752,7 @@ mod tests {
         assert_eq!(setup.fullmoves.get(), 2);
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_castling_right_without_rook() {
         let setup = "rRpppppp/8/8/8/8/8/PPPPPPBN/PPRQKBNR w KA"

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -375,8 +375,9 @@ impl Fen {
     /// ```
     /// use shakmaty::fen::Fen;
     ///
-    /// let fen = Fen::from_ascii(b"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
+    /// let fen = Fen::from_ascii(b"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")?;
     /// assert_eq!(fen, Fen::default());
+    /// # Ok::<_, shakmaty::fen::ParseFenError>(())
     /// ```
     pub fn from_ascii(fen: &[u8]) -> Result<Fen, ParseFenError> {
         let mut result = Setup::empty();

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -38,8 +38,9 @@
 //! ```
 //! use shakmaty::{fen::Fen, CastlingMode, Chess, Position};
 //!
-//! const FEN: &str =  "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4";
-//! let fen: Fen = FEN.parse().unwrap();
+//! let fen = "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4"
+//!     .parse::<Fen>()
+//!     .unwrap();
 //! let pos: Chess = fen.into_position(CastlingMode::Standard).unwrap();
 //! assert!(pos.is_checkmate());
 //! ```
@@ -374,8 +375,7 @@ impl Fen {
     /// ```
     /// use shakmaty::fen::Fen;
     ///
-    /// const FEN: &[u8] = b"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-    /// let fen = Fen::from_ascii(FEN).unwrap();
+    /// let fen = Fen::from_ascii(b"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
     /// assert_eq!(fen, Fen::default());
     /// ```
     pub fn from_ascii(fen: &[u8]) -> Result<Fen, ParseFenError> {

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -38,11 +38,15 @@
 //! ```
 //! use shakmaty::{fen::Fen, CastlingMode, Chess, Position};
 //!
-//! let fen = "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4"
-//!     .parse::<Fen>()
-//!     .unwrap();
-//! let pos: Chess = fen.into_position(CastlingMode::Standard).unwrap();
+//! let fen: Fen = "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4".parse()?;
+//! let pos: Chess = fen.into_position(CastlingMode::Standard)?;
 //! assert!(pos.is_checkmate());
+//!
+//! # use shakmaty::{fen::ParseFenError, PositionError};
+//! # #[derive(Debug)] struct CommonError;
+//! # impl From<ParseFenError> for CommonError { fn from(_: ParseFenError) -> Self { Self } }
+//! # impl<P> From<PositionError<P>> for CommonError { fn from(_: PositionError<P>) -> Self { Self } }
+//! # Ok::<_, CommonError>(())
 //! ```
 //!
 //! # Writing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,14 +37,13 @@
 //! # let pos = Chess::default();
 //!
 //! // 1. e4
-//! const MOVE: Move = Move::Normal {
+//! let pos = pos.play(&Move::Normal {
 //!     role: Role::Pawn,
 //!     from: Square::E2,
 //!     to: Square::E4,
 //!     capture: None,
 //!     promotion: None,
-//! };
-//! let pos = pos.play(&MOVE).unwrap();
+//! }).unwrap();
 //! ```
 //!
 //! Detect game end conditions:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub mod zobrist;
 #[cfg_attr(docs_rs, doc(cfg(feature = "variant")))]
 pub mod variant;
 
-pub use crate::{
+pub use {
     bitboard::Bitboard,
     board::Board,
     color::{ByColor, Color, ParseColorError},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,11 +68,18 @@
 //! * `step`: Implements [`std::iter::Step`] for `Square`, `File`, and `Rank`.
 //!   Requires nightly Rust.
 
+#![no_std]
 #![doc(html_root_url = "https://docs.rs/shakmaty/0.21.4")]
 #![forbid(unsafe_op_in_unsafe_fn)]
 #![warn(missing_debug_implementations)]
 #![cfg_attr(feature = "step", feature(step_trait))]
 #![cfg_attr(docs_rs, feature(doc_cfg))]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 mod color;
 mod magics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //! assert!(!pos.is_checkmate());
 //! assert!(!pos.is_stalemate());
 //! assert!(!pos.is_insufficient_material());
-//! assert!(pos.outcome().is_none()); // no winner yet
+//! assert_eq!(pos.outcome(), None); // no winner yet
 //! ```
 //!
 //! Also supports [FEN](fen), [SAN](san) and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,8 @@
 //!     to: Square::E4,
 //!     capture: None,
 //!     promotion: None,
-//! }).unwrap();
+//! })?;
+//! # Ok::<_, shakmaty::PlayError<_>>(())
 //! ```
 //!
 //! Detect game end conditions:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,7 @@
 //! assert!(!pos.is_checkmate());
 //! assert!(!pos.is_stalemate());
 //! assert!(!pos.is_insufficient_material());
-//!
-//! assert_eq!(pos.outcome(), None); // no winner yet
+//! assert!(pos.outcome().is_none()); // no winner yet
 //! ```
 //!
 //! Also supports [FEN](fen), [SAN](san) and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,11 @@
 //!
 //! # Feature flags
 //!
+//! * `alloc`: Enables APIs which require the [`alloc`] crate (e.g. FEN string rendering).
+//! * `std`: Implements the [`std::error::Error`] trait for various errors in the crate.
+//!   Implies the `alloc` feature (since [`std`] depends on [`alloc`] anyway). Enabled by
+//!   default for convenience. For `no_std` environments, this must be disabled with
+//!   `default-features = false`.
 //! * `variant`: Enables `shakmaty::variant` module for all Lichess variants.
 //! * `step`: Implements [`std::iter::Step`] for `Square`, `File`, and `Rank`.
 //!   Requires nightly Rust.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,14 +37,14 @@
 //! # let pos = Chess::default();
 //!
 //! // 1. e4
-//! let pos = pos.play(&Move::Normal {
+//! const MOVE: Move = Move::Normal {
 //!     role: Role::Pawn,
 //!     from: Square::E2,
 //!     to: Square::E4,
 //!     capture: None,
 //!     promotion: None,
-//! })?;
-//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! };
+//! let pos = pos.play(&MOVE).unwrap();
 //! ```
 //!
 //! Detect game end conditions:

--- a/src/position.rs
+++ b/src/position.rs
@@ -728,8 +728,9 @@ impl PartialEq for Chess {
 /// ```
 /// use shakmaty::{CastlingMode, Chess, fen::Fen};
 ///
-/// const FEN: &str = "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4";
-/// let fen: Fen = FEN.parse().unwrap();
+/// let fen = "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4"
+///     .parse::<Fen>()
+///     .unwrap();
 /// let position: Chess = fen.clone().into_position(CastlingMode::Standard).unwrap();
 /// let position_960: Chess = fen.into_position(CastlingMode::Chess960).unwrap();
 /// assert_eq!(position, position_960);

--- a/src/position.rs
+++ b/src/position.rs
@@ -315,8 +315,8 @@ pub trait FromSetup: Sized {
     ///
     /// let pos = Chess::from_setup(setup, CastlingMode::Standard)
     ///     .or_else(PositionError::ignore_impossible_material)
-    ///     .or_else(PositionError::ignore_impossible_check)?;
-    /// # Ok::<_, Box<dyn std::error::Error>>(())
+    ///     .or_else(PositionError::ignore_impossible_check)
+    ///     .unwrap();
     /// ```
     fn from_setup(setup: Setup, mode: CastlingMode) -> Result<Self, PositionError<Self>>;
 }
@@ -728,11 +728,11 @@ impl PartialEq for Chess {
 /// ```
 /// use shakmaty::{CastlingMode, Chess, fen::Fen};
 ///
-/// let fen: Fen = "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4".parse()?;
-/// let position: Chess = fen.clone().into_position(CastlingMode::Standard)?;
-/// let position_960: Chess = fen.into_position(CastlingMode::Chess960)?;
+/// const FEN: &str = "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4";
+/// let fen: Fen = FEN.parse().unwrap();
+/// let position: Chess = fen.clone().into_position(CastlingMode::Standard).unwrap();
+/// let position_960: Chess = fen.into_position(CastlingMode::Chess960).unwrap();
 /// assert_eq!(position, position_960);
-/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 impl Eq for Chess {}
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
-    error::Error,
+use core::{
     fmt,
     hash::{Hash, Hasher},
     num::NonZeroU32,
@@ -94,7 +93,8 @@ impl fmt::Display for ParseOutcomeError {
     }
 }
 
-impl Error for ParseOutcomeError {}
+#[cfg(feature = "std")]
+impl std::error::Error for ParseOutcomeError {}
 
 impl FromStr for Outcome {
     type Err = ParseOutcomeError;
@@ -124,7 +124,8 @@ impl<P: fmt::Debug> fmt::Display for PlayError<P> {
     }
 }
 
-impl<P: fmt::Debug> Error for PlayError<P> {}
+#[cfg(feature = "std")]
+impl<P: fmt::Debug> std::error::Error for PlayError<P> {}
 
 bitflags! {
     /// Reasons for a [`Setup`] not being a legal [`Position`].
@@ -284,7 +285,8 @@ impl<P> fmt::Display for PositionError<P> {
     }
 }
 
-impl<P> Error for PositionError<P> {}
+#[cfg(feature = "std")]
+impl<P> std::error::Error for PositionError<P> {}
 
 /// Validate and set up a playable [`Position`]. All provided chess variants
 /// support this.
@@ -3116,10 +3118,14 @@ fn filter_san_candidates(role: Role, to: Square, moves: &mut MoveList) {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "alloc")]
+    use alloc::string::ToString;
+
     use super::*;
     use crate::fen::Fen;
 
-    struct _AssertObjectSafe(Box<dyn Position>);
+    #[cfg(feature = "alloc")]
+    struct _AssertObjectSafe(alloc::boxed::Box<dyn Position>);
 
     fn setup_fen<T: Position + FromSetup>(fen: &str) -> T {
         fen.parse::<Fen>()
@@ -3465,6 +3471,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_swap_turn() {
         let pos: Chess = "rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 3"

--- a/src/position.rs
+++ b/src/position.rs
@@ -3121,9 +3121,6 @@ fn filter_san_candidates(role: Role, to: Square, moves: &mut MoveList) {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "alloc")]
-    use alloc::string::ToString;
-
     use super::*;
     use crate::fen::Fen;
 
@@ -3477,6 +3474,7 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn test_swap_turn() {
+        use alloc::string::ToString;
         let pos: Chess = "rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 3"
             .parse::<Fen>()
             .expect("valid fen")

--- a/src/position.rs
+++ b/src/position.rs
@@ -315,8 +315,10 @@ pub trait FromSetup: Sized {
     ///
     /// let pos = Chess::from_setup(setup, CastlingMode::Standard)
     ///     .or_else(PositionError::ignore_impossible_material)
-    ///     .or_else(PositionError::ignore_impossible_check)
-    ///     .unwrap();
+    ///
+    ///     .or_else(PositionError::ignore_impossible_check)?;
+    ///
+    /// # Ok::<_, PositionError<_>>(())
     /// ```
     fn from_setup(setup: Setup, mode: CastlingMode) -> Result<Self, PositionError<Self>>;
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -730,12 +730,16 @@ impl PartialEq for Chess {
 /// ```
 /// use shakmaty::{CastlingMode, Chess, fen::Fen};
 ///
-/// let fen = "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4"
-///     .parse::<Fen>()
-///     .unwrap();
-/// let position: Chess = fen.clone().into_position(CastlingMode::Standard).unwrap();
-/// let position_960: Chess = fen.into_position(CastlingMode::Chess960).unwrap();
+/// let fen: Fen = "r1bqkbnr/ppp2Qpp/2np4/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4".parse()?;
+/// let position: Chess = fen.clone().into_position(CastlingMode::Standard)?;
+/// let position_960: Chess = fen.into_position(CastlingMode::Chess960)?;
 /// assert_eq!(position, position_960);
+///
+/// # use shakmaty::{fen::ParseFenError, PositionError};
+/// # #[derive(Debug)] struct CommonError;
+/// # impl From<ParseFenError> for CommonError { fn from(_: ParseFenError) -> Self { Self } }
+/// # impl<P> From<PositionError<P>> for CommonError { fn from(_: PositionError<P>) -> Self { Self } }
+/// # Ok::<_, CommonError>(())
 /// ```
 impl Eq for Chess {}
 

--- a/src/role.rs
+++ b/src/role.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::{array, convert::identity, num};
+use core::{array, convert::identity, num};
 
 use crate::{color::Color, types::Piece, util::overflow_error};
 
@@ -164,7 +164,7 @@ nonzero_int_from_role_impl! {
 
 macro_rules! try_role_from_int_impl {
     ($($t:ty)+) => {
-        $(impl std::convert::TryFrom<$t> for Role {
+        $(impl core::convert::TryFrom<$t> for Role {
             type Error = num::TryFromIntError;
 
             #[inline]

--- a/src/san.rs
+++ b/src/san.rs
@@ -60,7 +60,7 @@
 //! # Ok::<_, Box<dyn std::error::Error>>(())
 //! ```
 
-use std::{error::Error, fmt, str::FromStr};
+use core::{fmt, str::FromStr};
 
 use crate::{CastlingSide, File, Move, MoveList, Outcome, Position, Rank, Role, Square};
 
@@ -74,7 +74,8 @@ impl fmt::Display for ParseSanError {
     }
 }
 
-impl Error for ParseSanError {}
+#[cfg(feature = "std")]
+impl std::error::Error for ParseSanError {}
 
 /// `IllegalSan` or `AmbiguousSan`.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -94,7 +95,8 @@ impl fmt::Display for SanError {
     }
 }
 
-impl Error for SanError {}
+#[cfg(feature = "std")]
+impl std::error::Error for SanError {}
 
 /// A move in Standard Algebraic Notation.
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -639,7 +641,9 @@ impl fmt::Display for SanPlus {
 
 #[cfg(test)]
 mod tests {
-    use std::mem;
+    #[cfg(feature = "alloc")]
+    use alloc::string::ToString;
+    use core::mem;
 
     use super::*;
     use crate::{fen::Fen, CastlingMode, Chess};
@@ -650,6 +654,7 @@ mod tests {
         assert!(mem::size_of::<SanPlus>() <= 8);
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_read_write() {
         for san in &[
@@ -681,6 +686,7 @@ mod tests {
         assert_eq!(san.to_move(&pos), Err(SanError::IllegalSan));
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_lax_pawn_move_san_roundtrip() {
         let san = "6h8".parse::<San>().expect("kinda valid san");

--- a/src/san.rs
+++ b/src/san.rs
@@ -23,9 +23,8 @@
 //! ```
 //! use shakmaty::{Chess, Position, san::San};
 //!
-//! let san: San = "Nf3".parse()?;
+//! let san: San = "Nf3".parse().unwrap();
 //! assert_eq!(san.to_string(), "Nf3");
-//! # Ok::<_, Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! Converting to a move:
@@ -34,9 +33,9 @@
 //! # use shakmaty::{Chess, Position, san::San};
 //! use shakmaty::{Square, Role, Move};
 //! #
-//! # let san: San = "Nf3".parse()?;
+//! # let san: San = "Nf3".parse().unwrap();
 //! let pos = Chess::default();
-//! let m = san.to_move(&pos)?;
+//! let m = san.to_move(&pos).unwrap();
 //!
 //! assert_eq!(m, Move::Normal {
 //!     role: Role::Knight,
@@ -45,7 +44,6 @@
 //!     to: Square::F3,
 //!     promotion: None,
 //! });
-//! # Ok::<_, Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! Back to a (possibly disambiguated) SAN:
@@ -54,10 +52,9 @@
 //! # use shakmaty::{Chess, Position, Role, san::San};
 //! #
 //! # let pos = Chess::default();
-//! # let san: San = "Nf3".parse()?;
-//! # let m = san.to_move(&pos)?;
+//! # let san: San = "Nf3".parse().unwrap();
+//! # let m = san.to_move(&pos).unwrap();
 //! assert_eq!(San::from_move(&pos, &m).to_string(), "Nf3");
-//! # Ok::<_, Box<dyn std::error::Error>>(())
 //! ```
 
 use core::{fmt, str::FromStr};
@@ -411,20 +408,19 @@ impl San {
     ///     promotion: None,
     /// };
     ///
-    /// let nf3 = San::from_ascii(b"Nf3")?;
+    /// let nf3 = San::from_ascii(b"Nf3").unwrap();
     /// assert!(nf3.matches(&m));
     ///
-    /// let ng1f3 = San::from_ascii(b"Ng1f3")?;
+    /// let ng1f3 = San::from_ascii(b"Ng1f3").unwrap();
     /// assert!(ng1f3.matches(&m));
     ///
     /// // capture does not match
-    /// let nxf3 = San::from_ascii(b"Nxf3")?;
+    /// let nxf3 = San::from_ascii(b"Nxf3").unwrap();
     /// assert!(!nxf3.matches(&m));
     ///
     /// // other file does not match
-    /// let nef3 = San::from_ascii(b"Nef3")?;
+    /// let nef3 = San::from_ascii(b"Nef3").unwrap();
     /// assert!(!nef3.matches(&m));
-    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn matches(&self, m: &Move) -> bool {
         match *self {

--- a/src/san.rs
+++ b/src/san.rs
@@ -23,8 +23,9 @@
 //! ```
 //! use shakmaty::{Chess, Position, san::San};
 //!
-//! let san: San = "Nf3".parse().unwrap();
+//! let san: San = "Nf3".parse()?;
 //! assert_eq!(san.to_string(), "Nf3");
+//! # Ok::<_, shakmaty::san::ParseSanError>(())
 //! ```
 //!
 //! Converting to a move:
@@ -408,19 +409,21 @@ impl San {
     ///     promotion: None,
     /// };
     ///
-    /// let nf3 = San::from_ascii(b"Nf3").unwrap();
+    /// let nf3 = San::from_ascii(b"Nf3")?;
     /// assert!(nf3.matches(&m));
     ///
-    /// let ng1f3 = San::from_ascii(b"Ng1f3").unwrap();
+    /// let ng1f3 = San::from_ascii(b"Ng1f3")?;
     /// assert!(ng1f3.matches(&m));
     ///
     /// // capture does not match
-    /// let nxf3 = San::from_ascii(b"Nxf3").unwrap();
+    /// let nxf3 = San::from_ascii(b"Nxf3")?;
     /// assert!(!nxf3.matches(&m));
     ///
     /// // other file does not match
-    /// let nef3 = San::from_ascii(b"Nef3").unwrap();
+    /// let nef3 = San::from_ascii(b"Nef3")?;
     /// assert!(!nef3.matches(&m));
+    ///
+    /// # Ok::<_, shakmaty::san::ParseSanError>(())
     /// ```
     pub fn matches(&self, m: &Move) -> bool {
         match *self {

--- a/src/san.rs
+++ b/src/san.rs
@@ -31,12 +31,12 @@
 //! Converting to a move:
 //!
 //! ```
-//! # use shakmaty::{Chess, Position, san::San};
+//! # use shakmaty::{Chess, Position, san::{ParseSanError, San, SanError}};
 //! use shakmaty::{Square, Role, Move};
 //! #
-//! # let san: San = "Nf3".parse().unwrap();
+//! # let san: San = "Nf3".parse()?;
 //! let pos = Chess::default();
-//! let m = san.to_move(&pos).unwrap();
+//! let m = san.to_move(&pos)?;
 //!
 //! assert_eq!(m, Move::Normal {
 //!     role: Role::Knight,
@@ -45,17 +45,27 @@
 //!     to: Square::F3,
 //!     promotion: None,
 //! });
+//!
+//! # #[derive(Debug)] struct CommonError;
+//! # impl From<ParseSanError> for CommonError { fn from(_: ParseSanError) -> Self { Self } }
+//! # impl From<SanError> for CommonError { fn from(_: SanError) -> Self { Self } }
+//! # Ok::<_, CommonError>(())
 //! ```
 //!
 //! Back to a (possibly disambiguated) SAN:
 //!
 //! ```
-//! # use shakmaty::{Chess, Position, Role, san::San};
+//! # use shakmaty::{Chess, Position, Role, san::{ParseSanError, San, SanError}};
 //! #
 //! # let pos = Chess::default();
-//! # let san: San = "Nf3".parse().unwrap();
-//! # let m = san.to_move(&pos).unwrap();
+//! # let san: San = "Nf3".parse()?;
+//! # let m = san.to_move(&pos)?;
 //! assert_eq!(San::from_move(&pos, &m).to_string(), "Nf3");
+//!
+//! # #[derive(Debug)] struct CommonError;
+//! # impl From<ParseSanError> for CommonError { fn from(_: ParseSanError) -> Self { Self } }
+//! # impl From<SanError> for CommonError { fn from(_: SanError) -> Self { Self } }
+//! # Ok::<_, CommonError>(())
 //! ```
 
 use core::{fmt, str::FromStr};

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::num::NonZeroU32;
+use core::num::NonZeroU32;
 
 use crate::{
     attacks, Bitboard, Board, ByColor, ByRole, CastlingMode, CastlingSide, Color, File, FromSetup,

--- a/src/square.rs
+++ b/src/square.rs
@@ -61,7 +61,7 @@ macro_rules! unsafe_step_impl {
     ($type:ty) => {
         #[cfg(feature = "step")]
         #[cfg_attr(docs_rs, doc(cfg(feature = "step")))]
-        impl std::iter::Step for $type {
+        impl core::iter::Step for $type {
             fn steps_between(start: &Self, end: &Self) -> Option<usize> {
                 usize::from(*end).checked_sub(usize::from(*start))
             }

--- a/src/square.rs
+++ b/src/square.rs
@@ -14,10 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
+use core::{
     cmp::max,
     convert::TryInto,
-    error::Error,
     fmt::{self, Write as _},
     mem,
     num::TryFromIntError,
@@ -41,7 +40,7 @@ macro_rules! from_repr_u8_impl {
 
 macro_rules! try_from_int_impl {
     ($type:ty, $lower:expr, $upper:expr, $($t:ty)+) => {
-        $(impl std::convert::TryFrom<$t> for $type {
+        $(impl core::convert::TryFrom<$t> for $type {
             type Error = TryFromIntError;
 
             #[inline]
@@ -68,14 +67,14 @@ macro_rules! unsafe_step_impl {
             }
 
             fn forward_checked(start: Self, count: usize) -> Option<Self> {
-                use std::convert::TryFrom as _;
+                use core::convert::TryFrom as _;
                 i32::try_from(count)
                     .ok()
                     .and_then(|count| start.offset(count))
             }
 
             fn backward_checked(start: Self, count: usize) -> Option<Self> {
-                use std::convert::TryFrom as _;
+                use core::convert::TryFrom as _;
                 i32::try_from(count)
                     .ok()
                     .and_then(|count| start.offset(-count))
@@ -84,7 +83,7 @@ macro_rules! unsafe_step_impl {
             unsafe fn forward_unchecked(start: Self, count: usize) -> Self {
                 // Safety: It is the callers responsibility to ensure
                 // start + count is in the range of Self.
-                debug_assert!(count < 64);
+                core::debug_assert!(count < 64);
                 let count = count as u32;
                 unsafe { Self::new_unchecked(u32::from(start) + count) }
             }
@@ -92,7 +91,7 @@ macro_rules! unsafe_step_impl {
             unsafe fn backward_unchecked(start: Self, count: usize) -> Self {
                 // Safety: It is the callers responsibility to ensure
                 // start - count is in the range of Self.
-                debug_assert!(count < 64);
+                core::debug_assert!(count < 64);
                 let count = count as u32;
                 unsafe { Self::new_unchecked(u32::from(start) - count) }
             }
@@ -347,7 +346,8 @@ impl fmt::Display for ParseSquareError {
     }
 }
 
-impl Error for ParseSquareError {}
+#[cfg(feature = "std")]
+impl std::error::Error for ParseSquareError {}
 
 /// A square of the chessboard.
 #[rustfmt::skip]

--- a/src/square.rs
+++ b/src/square.rs
@@ -423,12 +423,10 @@ impl Square {
     /// # Example
     ///
     /// ```
-    /// # use std::error::Error;
-    /// #
     /// use shakmaty::Square;
-    ///
-    /// let sq = Square::from_ascii(b"a5").unwrap();
+    /// let sq = Square::from_ascii(b"a5")?;
     /// assert_eq!(sq, Square::A5);
+    /// # Ok::<_, shakmaty::ParseSquareError>(())
     /// ```
     #[inline]
     pub fn from_ascii(s: &[u8]) -> Result<Square, ParseSquareError> {

--- a/src/square.rs
+++ b/src/square.rs
@@ -427,10 +427,8 @@ impl Square {
     /// #
     /// use shakmaty::Square;
     ///
-    /// let sq = Square::from_ascii(b"a5")?;
+    /// let sq = Square::from_ascii(b"a5").unwrap();
     /// assert_eq!(sq, Square::A5);
-    /// #
-    /// # Ok::<_, Box<dyn Error>>(())
     /// ```
     #[inline]
     pub fn from_ascii(s: &[u8]) -> Result<Square, ParseSquareError> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::{
+use core::{
     fmt::{self, Write as _},
     num,
 };
@@ -328,7 +328,7 @@ pub enum EnPassantMode {
 
 #[cfg(test)]
 mod tests {
-    use std::mem;
+    use core::mem;
 
     use super::*;
 
@@ -410,7 +410,7 @@ int_from_remaining_checks_impl! { u8 i8 u16 i16 u32 i32 u64 i64 usize isize }
 
 macro_rules! try_remaining_checks_from_int_impl {
     ($($t:ty)+) => {
-        $(impl std::convert::TryFrom<$t> for RemainingChecks {
+        $(impl core::convert::TryFrom<$t> for RemainingChecks {
             type Error = num::TryFromIntError;
 
             #[inline]

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -23,14 +23,13 @@
 //! ```
 //! use shakmaty::{Square, uci::Uci};
 //!
-//! let uci: Uci = "g1f3".parse()?;
+//! let uci: Uci = "g1f3".parse().unwrap();
 //!
 //! assert_eq!(uci, Uci::Normal {
 //!     from: Square::G1,
 //!     to: Square::F3,
 //!     promotion: None,
-//! });
-//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! })
 //! ```
 //!
 //! Converting to a legal move in the context of a position:
@@ -39,13 +38,12 @@
 //! # use shakmaty::{Square, uci::Uci};
 //! use shakmaty::{Color::White, Chess, Setup, Position};
 //!
-//! # let uci: Uci = "g1f3".parse()?;
+//! # let uci: Uci = "g1f3".parse().unwrap();
 //! let mut pos = Chess::default();
-//! let m = uci.to_move(&pos)?;
+//! let m = uci.to_move(&pos).unwrap();
 //!
 //! pos.play_unchecked(&m);
 //! assert_eq!(pos.board().piece_at(Square::F3), Some(White.knight()));
-//! # Ok::<_, Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! Converting from [`Move`] to [`Uci`]:
@@ -159,14 +157,13 @@ impl Uci {
     /// ```
     /// use shakmaty::{Square, uci::Uci};
     ///
-    /// let uci = Uci::from_ascii(b"e4e5")?;
+    /// let uci = Uci::from_ascii(b"e4e5").unwrap();
     ///
     /// assert_eq!(uci, Uci::Normal {
     ///     from: Square::E4,
     ///     to: Square::E5,
     ///     promotion: None,
     /// });
-    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn from_ascii(uci: &[u8]) -> Result<Uci, ParseUciError> {
         if uci.len() != 4 && uci.len() != 5 {

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -37,15 +37,20 @@
 //! Converting to a legal move in the context of a position:
 //!
 //! ```
-//! # use shakmaty::{Square, uci::Uci};
+//! # use shakmaty::{Square, uci::{IllegalUciError, ParseUciError, Uci}};
 //! use shakmaty::{Color::White, Chess, Setup, Position};
 //!
-//! # let uci: Uci = "g1f3".parse().unwrap();
+//! # let uci: Uci = "g1f3".parse()?;
 //! let mut pos = Chess::default();
-//! let m = uci.to_move(&pos).unwrap();
+//! let m = uci.to_move(&pos)?;
 //!
 //! pos.play_unchecked(&m);
 //! assert_eq!(pos.board().piece_at(Square::F3), Some(White.knight()));
+//!
+//! # #[derive(Debug)] struct CommonError;
+//! # impl From<IllegalUciError> for CommonError { fn from(_: IllegalUciError) -> Self { Self } }
+//! # impl From<ParseUciError> for CommonError { fn from(_: ParseUciError) -> Self { Self } }
+//! # Ok::<_, CommonError>(())
 //! ```
 //!
 //! Converting from [`Move`] to [`Uci`]:

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -23,13 +23,15 @@
 //! ```
 //! use shakmaty::{Square, uci::Uci};
 //!
-//! let uci: Uci = "g1f3".parse().unwrap();
+//! let uci: Uci = "g1f3".parse()?;
 //!
 //! assert_eq!(uci, Uci::Normal {
 //!     from: Square::G1,
 //!     to: Square::F3,
 //!     promotion: None,
-//! })
+//! });
+//!
+//! # Ok::<_, shakmaty::uci::ParseUciError>(())
 //! ```
 //!
 //! Converting to a legal move in the context of a position:
@@ -157,13 +159,15 @@ impl Uci {
     /// ```
     /// use shakmaty::{Square, uci::Uci};
     ///
-    /// let uci = Uci::from_ascii(b"e4e5").unwrap();
+    /// let uci = Uci::from_ascii(b"e4e5")?;
     ///
     /// assert_eq!(uci, Uci::Normal {
     ///     from: Square::E4,
     ///     to: Square::E5,
     ///     promotion: None,
     /// });
+    ///
+    /// # Ok::<_, shakmaty::uci::ParseUciError>(())
     /// ```
     pub fn from_ascii(uci: &[u8]) -> Result<Uci, ParseUciError> {
         if uci.len() != 4 && uci.len() != 5 {

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -75,7 +75,7 @@
 //!
 //! [`Move`]: super::Move
 
-use std::{error::Error, fmt, str::FromStr};
+use core::{fmt, str::FromStr};
 
 use crate::{CastlingMode, CastlingSide, Move, Position, Rank, Role, Square};
 
@@ -89,7 +89,8 @@ impl fmt::Display for ParseUciError {
     }
 }
 
-impl Error for ParseUciError {}
+#[cfg(feature = "std")]
+impl std::error::Error for ParseUciError {}
 
 /// Error when UCI is illegal.
 #[derive(Clone, Debug)]
@@ -101,7 +102,8 @@ impl fmt::Display for IllegalUciError {
     }
 }
 
-impl Error for IllegalUciError {}
+#[cfg(feature = "std")]
+impl std::error::Error for IllegalUciError {}
 
 /// A move as represented in the UCI protocol.
 #[derive(Clone, Eq, PartialEq, Debug, Hash)]
@@ -363,6 +365,9 @@ impl Move {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "alloc")]
+    use alloc::string::ToString;
+
     use super::*;
     use crate::{fen::Fen, Chess, EnPassantMode};
 
@@ -461,6 +466,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn test_uci_to_castles() {
         let mut pos: Chess = "nbqrknbr/pppppppp/8/8/8/8/PPPPPPPP/NBQRKNBR w KQkq - 0 1"

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -366,11 +366,8 @@ impl Move {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "alloc")]
-    use alloc::string::ToString;
-
     use super::*;
-    use crate::{fen::Fen, Chess, EnPassantMode};
+    use crate::{fen::Fen, Chess};
 
     #[test]
     pub fn test_uci_to_en_passant() {
@@ -470,6 +467,7 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn test_uci_to_castles() {
+        use alloc::string::ToString;
         let mut pos: Chess = "nbqrknbr/pppppppp/8/8/8/8/PPPPPPPP/NBQRKNBR w KQkq - 0 1"
             .parse::<Fen>()
             .expect("valid fen")
@@ -484,7 +482,7 @@ mod tests {
             pos.play_unchecked(&m);
         }
         assert_eq!(
-            Fen::from_position(pos, EnPassantMode::Legal).to_string(),
+            Fen::from_position(pos, crate::EnPassantMode::Legal).to_string(),
             "nbkr1nbr/ppp1pppp/3p4/8/5Pq1/6N1/PPPPPBPP/NBQR1RK1 b - - 5 4"
         );
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::{convert::TryFrom as _, num::TryFromIntError};
+use core::{convert::TryFrom as _, num::TryFromIntError};
 
 pub(crate) fn overflow_error() -> TryFromIntError {
     // This is a hack to construct TryFromIntError despite its private

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -19,7 +19,7 @@
 //! These are games played with normal chess pieces but special rules.
 //! Every chess variant implements [`FromSetup`] and [`Position`].
 
-use std::{num::NonZeroU32, str};
+use core::{num::NonZeroU32, str};
 
 pub use crate::position::{
     variant::{Antichess, Atomic, Crazyhouse, Horde, KingOfTheHill, RacingKings, ThreeCheck},

--- a/src/zobrist.rs
+++ b/src/zobrist.rs
@@ -203,19 +203,19 @@ mod variant {
 /// assert_eq!(pos.zobrist_hash(), 0x463b96181691fc9c); // cached
 ///
 /// // 1. e4
-/// let pos = pos
-///     .play(&Move::Normal {
-///         role: Role::Pawn,
-///         from: Square::E2,
-///         to: Square::E4,
-///         capture: None,
-///         promotion: None,
-///     })
-///     .unwrap();
+/// let pos = pos.play(&Move::Normal {
+///     role: Role::Pawn,
+///     from: Square::E2,
+///     to: Square::E4,
+///     capture: None,
+///     promotion: None,
+/// })?;
 ///
 /// // Incrementally updated (or recomputed from scratch if incremental
 /// // updates not supported).
 /// assert_eq!(pos.zobrist_hash(), 0x823c9b50fd114196);
+///
+/// # Ok::<_, shakmaty::PlayError<_>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct Zobrist<P, V: ZobristValue> {

--- a/src/zobrist.rs
+++ b/src/zobrist.rs
@@ -203,18 +203,19 @@ mod variant {
 /// assert_eq!(pos.zobrist_hash(), 0x463b96181691fc9c); // cached
 ///
 /// // 1. e4
-/// let pos = pos.play(&Move::Normal {
-///     role: Role::Pawn,
-///     from: Square::E2,
-///     to: Square::E4,
-///     capture: None,
-///     promotion: None,
-/// })?;
+/// let pos = pos
+///     .play(&Move::Normal {
+///         role: Role::Pawn,
+///         from: Square::E2,
+///         to: Square::E4,
+///         capture: None,
+///         promotion: None,
+///     })
+///     .unwrap();
 ///
 /// // Incrementally updated (or recomputed from scratch if incremental
 /// // updates not supported).
 /// assert_eq!(pos.zobrist_hash(), 0x823c9b50fd114196);
-/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct Zobrist<P, V: ZobristValue> {

--- a/src/zobrist.rs
+++ b/src/zobrist.rs
@@ -31,7 +31,7 @@
 //! assert_eq!(pos.zobrist_hash::<u64>(), 0x463b96181691fc9c);
 //! ```
 
-use std::{cell::Cell, num::NonZeroU32, ops::BitXorAssign};
+use core::{cell::Cell, num::NonZeroU32, ops::BitXorAssign};
 
 use crate::{
     color::ByColor, Bitboard, Board, ByRole, Castles, CastlingMode, CastlingSide, Chess, Color,


### PR DESCRIPTION
Hello there!

This PR was originally supposed to be a "`const`-ification" of various functions in this crate. However, that work will be saved for a later PR because I realized that this crate can greatly benefit from being run in `no_std` environments.

Aside from the occasional Clippy cleanup, the changes I've made mostly renames `std` imports as `core` imports instead. The only issue that arose was from the `std::error::Error` trait, which (as of writing) has not been merged into the `core` crate yet (see rust-lang/project-error-handling#3).

There were also some tests and methods in the crate that required the `alloc` crate. These were mostly functions that rendered formatted boards to a `String`.

# New Feature Flags
To resolve the `std` and `alloc` issues above, I introduce two new feature flags: `std` and `alloc`. As its name suggests, the `alloc` feature enables APIs that render boards to formatted outputs (e.g. `String`).

Meanwhile, the `std` feature implies `alloc`. This feature is only used to enable `std::error::Error` trait implementations in the crate. In a perfect world, `std` is not necessary for this crate. But until `std::error::Error` is moved to `core`, this is a necessary feature for now.

# New Methods and Deprecations
In line with the effort to isolate allocations, the `Board::board_fen` method has been deprecated in favor of the newer, more generic `Board::display_with_promotions` method. The main issue with the `board_fen` is that it unconditionally allocates a new `String` for each invocation. In a `no_std` environment, this is undesirable.

This is why I've extracted the core formatting logic elsewhere. The `display_with_promotions` method returns a `struct` that implements `Display`. It performs the same algorithm as `board_fen`, but is now generic over the formatting output.

```rust
let board = shakmaty::Board::empty();

// Deprecated!
let new_string = board.board_fen(shakmaty::BitBoard::EMPTY);
println!("{new_string}");

// More generic version, which does not require allocations all the time.
let display = board.display_with_promotions(promoted);
println!("{display}");

// But we also have the freedom to allocate a new string if we want to.
let another_string = display.to_string();
```

To maintain backwards-compatibility, I have annotated `board_fen` as `#[deprecated]`. I also gated it behind the `alloc` feature. This should be compatible with previous versions of the crate because `std` is enabled by default. We should, however, consider removing this method in the future.