### PR TITLE
feat!: `const`-ify all the things!

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - "1.60.0"
+          - "1.61.0"
           - "stable"
           - "beta"
           - "nightly"

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -52,20 +52,20 @@ pub struct Bitboard(pub u64);
 impl Bitboard {
     /// A bitboard with a single square.
     #[inline]
-    pub const fn from_square(sq: Square) -> Bitboard {
-        Bitboard(SQUARES[sq as usize])
+    pub const fn from_square(sq: Square) -> Self {
+        Self(SQUARES[sq as usize])
     }
 
     /// Returns the bitboard containing all squares of the given rank.
     #[inline]
-    pub const fn from_rank(rank: Rank) -> Bitboard {
-        Bitboard(RANKS[rank as usize])
+    pub const fn from_rank(rank: Rank) -> Self {
+        Self(RANKS[rank as usize])
     }
 
     /// Returns the bitboard containing all squares of the given file.
     #[inline]
-    pub const fn from_file(file: File) -> Bitboard {
-        Bitboard(FILES[file as usize])
+    pub const fn from_file(file: File) -> Self {
+        Self(FILES[file as usize])
     }
 
     /// Shift using `<<` for `White` and `>>` for `Black`.
@@ -89,11 +89,11 @@ impl Bitboard {
     #[deprecated = "use Bitboard::shift() or manual shifts for clearer semantics"]
     #[must_use]
     #[inline]
-    pub const fn relative_shift(self, color: Color, shift: u32) -> Bitboard {
-        match color {
-            Color::White => Bitboard(self.0 << shift),
-            Color::Black => Bitboard(self.0 >> shift),
-        }
+    pub const fn relative_shift(self, color: Color, shift: u32) -> Self {
+        Self(match color {
+            Color::White => self.0 << shift,
+            Color::Black => self.0 >> shift,
+        })
     }
 
     /// Silently overflowing bitwise shift with a signed offset, `<<` for
@@ -120,8 +120,8 @@ impl Bitboard {
     /// ```
     #[must_use]
     #[inline]
-    pub const fn shift(self, offset: i32) -> Bitboard {
-        Bitboard(if offset > 63 {
+    pub const fn shift(self, offset: i32) -> Self {
+        Self(if offset > 63 {
             0
         } else if offset >= 0 {
             self.0 << offset
@@ -169,19 +169,19 @@ impl Bitboard {
 
     /// Adds `squares`.
     #[inline]
-    pub fn add<T: Into<Bitboard>>(&mut self, squares: T) {
+    pub fn add<T: Into<Self>>(&mut self, squares: T) {
         *self |= squares;
     }
 
     /// Toggles `squares`.
     #[inline]
-    pub fn toggle<T: Into<Bitboard>>(&mut self, squares: T) {
+    pub fn toggle<T: Into<Self>>(&mut self, squares: T) {
         *self ^= squares;
     }
 
     /// Discards `squares`.
     #[inline]
-    pub fn discard<T: Into<Bitboard>>(&mut self, squares: T) {
+    pub fn discard<T: Into<Self>>(&mut self, squares: T) {
         *self &= !squares.into();
     }
 
@@ -227,7 +227,7 @@ impl Bitboard {
     }
 
     /// Returns the intersection of `self` and `squares`. Equivalent to bitwise `&`.
-    pub const fn intersect(self, squares: Bitboard) -> Bitboard {
+    pub const fn intersect(self, squares: Self) -> Self {
         Self(self.0 & squares.0)
     }
 
@@ -235,12 +235,12 @@ impl Bitboard {
     #[doc(alias = "union")]
     #[must_use]
     #[inline]
-    pub fn with<T: Into<Bitboard>>(self, squares: T) -> Bitboard {
+    pub fn with<T: Into<Self>>(self, squares: T) -> Self {
         self.with_const(squares.into())
     }
 
     /// Same as the `with` method, but usable in `const` contexts.
-    pub const fn with_const(self, squares: Bitboard) -> Bitboard {
+    pub const fn with_const(self, squares: Self) -> Self {
         Self(self.0 | squares.0)
     }
 
@@ -248,12 +248,12 @@ impl Bitboard {
     #[doc(alias = "difference")]
     #[must_use]
     #[inline]
-    pub fn without<T: Into<Bitboard>>(self, squares: T) -> Bitboard {
+    pub fn without<T: Into<Self>>(self, squares: T) -> Self {
         self.without_const(squares.into())
     }
 
     /// Same as the `without` method, but usable in `const` contexts.
-    pub const fn without_const(self, squares: Bitboard) -> Bitboard {
+    pub const fn without_const(self, squares: Self) -> Self {
         Self(self.0 & !squares.0)
     }
 
@@ -262,23 +262,23 @@ impl Bitboard {
     #[doc(alias = "symmetric_difference")]
     #[must_use]
     #[inline]
-    pub fn toggled<T: Into<Bitboard>>(self, squares: T) -> Bitboard {
+    pub fn toggled<T: Into<Self>>(self, squares: T) -> Self {
         self.toggled_const(squares.into())
     }
 
     /// Same as the `toggled` method, but usable in `const` contexts.
-    pub const fn toggled_const(self, squares: Bitboard) -> Bitboard {
+    pub const fn toggled_const(self, squares: Self) -> Self {
         Self(self.0 ^ squares.0)
     }
 
     /// Tests if `self` and `other` are disjoint.
     #[inline]
-    pub fn is_disjoint<T: Into<Bitboard>>(self, other: T) -> bool {
+    pub fn is_disjoint<T: Into<Self>>(self, other: T) -> bool {
         self.is_disjoint_const(other.into())
     }
 
     /// Same as the `is_disjoint` method, but usable in `const` contexts.
-    pub const fn is_disjoint_const(self, other: Bitboard) -> bool {
+    pub const fn is_disjoint_const(self, other: Self) -> bool {
         Self(self.0 & other.0).is_empty()
     }
 
@@ -292,12 +292,12 @@ impl Bitboard {
     /// assert!(Bitboard::DARK_SQUARES.is_subset(Bitboard::FULL));
     /// ```
     #[inline]
-    pub fn is_subset<T: Into<Bitboard>>(self, other: T) -> bool {
+    pub fn is_subset<T: Into<Self>>(self, other: T) -> bool {
         self.is_subset_const(other.into())
     }
 
     /// Same as the `is_subset` method, but usable in `const` contexts.
-    pub const fn is_subset_const(self, other: Bitboard) -> bool {
+    pub const fn is_subset_const(self, other: Self) -> bool {
         self.without_const(other).is_empty()
     }
 
@@ -311,12 +311,12 @@ impl Bitboard {
     /// assert!(Bitboard::FULL.is_superset(Bitboard::LIGHT_SQUARES));
     /// ```
     #[inline]
-    pub fn is_superset<T: Into<Bitboard>>(self, other: T) -> bool {
+    pub fn is_superset<T: Into<Self>>(self, other: T) -> bool {
         self.is_superset_const(other.into())
     }
 
     /// Same as the `is_superset` method, but usable in `const` contexts.
-    pub const fn is_superset_const(self, other: Bitboard) -> bool {
+    pub const fn is_superset_const(self, other: Self) -> bool {
         other.is_subset_const(self)
     }
 
@@ -347,7 +347,7 @@ impl Bitboard {
 
     /// Returns `self` without the first square.
     #[inline]
-    pub const fn without_first(self) -> Bitboard {
+    pub const fn without_first(self) -> Self {
         let Self(mask) = self;
         Self(mask & mask.wrapping_sub(1))
     }
@@ -356,7 +356,7 @@ impl Bitboard {
     #[inline]
     pub fn pop_back(&mut self) -> Option<Square> {
         let square = self.last();
-        *self ^= Bitboard::from_iter(square);
+        *self ^= Self::from_iter(square);
         square
     }
 
@@ -450,7 +450,7 @@ impl Bitboard {
     /// ```
     #[must_use]
     #[inline]
-    pub const fn flip_vertical(self) -> Bitboard {
+    pub const fn flip_vertical(self) -> Self {
         Self(self.0.swap_bytes())
     }
 
@@ -473,7 +473,7 @@ impl Bitboard {
     /// // . . 1 . . . 1 .
     /// ```
     #[must_use]
-    pub const fn flip_horizontal(self) -> Bitboard {
+    pub const fn flip_horizontal(self) -> Self {
         // https://www.chessprogramming.org/Flipping_Mirroring_and_Rotating#Horizontal
         let k1 = 0x5555_5555_5555_5555;
         let k2 = 0x3333_3333_3333_3333;
@@ -482,7 +482,7 @@ impl Bitboard {
         let x = ((x >> 1) & k1) | ((x & k1) << 1);
         let x = ((x >> 2) & k2) | ((x & k2) << 2);
         let x = ((x >> 4) & k4) | ((x & k4) << 4);
-        Bitboard(x)
+        Self(x)
     }
 
     /// Mirror the bitboard at the a1-h8 diagonal.
@@ -504,7 +504,7 @@ impl Bitboard {
     /// // . . . . . . . .
     /// ```
     #[must_use]
-    pub const fn flip_diagonal(self) -> Bitboard {
+    pub const fn flip_diagonal(self) -> Self {
         // https://www.chessprogramming.org/Flipping_Mirroring_and_Rotating#Diagonal
         let k1 = 0x5500_5500_5500_5500;
         let k2 = 0x3333_0000_3333_0000;
@@ -516,7 +516,7 @@ impl Bitboard {
         x ^= t ^ (t >> 14);
         let t = k1 & (x ^ (x << 7));
         x ^= t ^ (t >> 7);
-        Bitboard(x)
+        Self(x)
     }
 
     /// Mirror the bitboard at the h1-a8 diagonal.
@@ -538,7 +538,7 @@ impl Bitboard {
     /// // . . . . . . . .
     /// ```
     #[must_use]
-    pub const fn flip_anti_diagonal(self) -> Bitboard {
+    pub const fn flip_anti_diagonal(self) -> Self {
         // https://www.chessprogramming.org/Flipping_Mirroring_and_Rotating#Anti-Diagonal
         let k1 = 0xaa00_aa00_aa00_aa00;
         let k2 = 0xcccc_0000_cccc_0000;
@@ -550,7 +550,7 @@ impl Bitboard {
         x ^= t ^ (t >> 18);
         let t = k1 & (x ^ (x << 9));
         x ^= t ^ (t >> 9);
-        Bitboard(x)
+        Self(x)
     }
 
     /// Rotate the bitboard 90 degrees clockwise.
@@ -572,7 +572,7 @@ impl Bitboard {
     /// // . . . . . . . .
     /// ```
     #[must_use]
-    pub const fn rotate_90(self) -> Bitboard {
+    pub const fn rotate_90(self) -> Self {
         self.flip_diagonal().flip_vertical()
     }
 
@@ -596,8 +596,8 @@ impl Bitboard {
     /// ```
     #[must_use]
     #[inline]
-    pub const fn rotate_180(self) -> Bitboard {
-        Bitboard(self.0.reverse_bits())
+    pub const fn rotate_180(self) -> Self {
+        Self(self.0.reverse_bits())
     }
 
     /// Rotate the bitboard 270 degrees clockwise.
@@ -619,7 +619,7 @@ impl Bitboard {
     /// // . . . . . . . .
     /// ```
     #[must_use]
-    pub const fn rotate_270(self) -> Bitboard {
+    pub const fn rotate_270(self) -> Self {
         self.flip_vertical().flip_diagonal()
     }
 
@@ -638,7 +638,7 @@ impl Bitboard {
     /// // . . . . . . . .
     /// // . . . . . . . .
     /// ```
-    pub const EMPTY: Bitboard = Bitboard(0);
+    pub const EMPTY: Self = Self(0);
 
     /// A bitboard containing all squares.
     ///
@@ -655,7 +655,7 @@ impl Bitboard {
     /// // 1 1 1 1 1 1 1 1
     /// // 1 1 1 1 1 1 1 1
     /// ```
-    pub const FULL: Bitboard = Bitboard(!0);
+    pub const FULL: Self = Self(!0);
 
     /// All dark squares.
     ///
@@ -672,7 +672,7 @@ impl Bitboard {
     /// // . 1 . 1 . 1 . 1
     /// // 1 . 1 . 1 . 1 .
     /// ```
-    pub const DARK_SQUARES: Bitboard = Bitboard(0xaa55_aa55_aa55_aa55);
+    pub const DARK_SQUARES: Self = Self(0xaa55_aa55_aa55_aa55);
 
     /// All light squares.
     ///
@@ -689,7 +689,7 @@ impl Bitboard {
     /// // 1 . 1 . 1 . 1 .
     /// // . 1 . 1 . 1 . 1
     /// ```
-    pub const LIGHT_SQUARES: Bitboard = Bitboard(0x55aa_55aa_55aa_55aa);
+    pub const LIGHT_SQUARES: Self = Self(0x55aa_55aa_55aa_55aa);
 
     /// The four corner squares.
     ///
@@ -706,7 +706,7 @@ impl Bitboard {
     /// // . . . . . . . .
     /// // 1 . . . . . . 1
     /// ```
-    pub const CORNERS: Bitboard = Bitboard(0x8100_0000_0000_0081);
+    pub const CORNERS: Self = Self(0x8100_0000_0000_0081);
 
     /// The backranks.
     ///
@@ -723,7 +723,7 @@ impl Bitboard {
     /// // . . . . . . . .
     /// // 1 1 1 1 1 1 1 1
     /// ```
-    pub const BACKRANKS: Bitboard = Bitboard(0xff00_0000_0000_00ff);
+    pub const BACKRANKS: Self = Self(0xff00_0000_0000_00ff);
 
     /// The four center squares.
     ///
@@ -740,7 +740,7 @@ impl Bitboard {
     /// // . . . . . . . .
     /// // . . . . . . . .
     /// ```
-    pub const CENTER: Bitboard = Bitboard(0x0000_0018_1800_0000);
+    pub const CENTER: Self = Self(0x0000_0018_1800_0000);
 
     /// The northern half of the board.
     ///
@@ -757,7 +757,7 @@ impl Bitboard {
     /// // . . . . . . . .
     /// // . . . . . . . .
     /// ```
-    pub const NORTH: Bitboard = Bitboard(0xffff_ffff_0000_0000);
+    pub const NORTH: Self = Self(0xffff_ffff_0000_0000);
 
     /// The southern half of the board.
     ///
@@ -774,7 +774,7 @@ impl Bitboard {
     /// // 1 1 1 1 1 1 1 1
     /// // 1 1 1 1 1 1 1 1
     /// ```
-    pub const SOUTH: Bitboard = Bitboard(0x0000_0000_ffff_ffff);
+    pub const SOUTH: Self = Self(0x0000_0000_ffff_ffff);
 
     /// The western half of the board.
     ///
@@ -791,7 +791,7 @@ impl Bitboard {
     /// // 1 1 1 1 . . . .
     /// // 1 1 1 1 . . . .
     /// ```
-    pub const WEST: Bitboard = Bitboard(0x0f0f_0f0f_0f0f_0f0f);
+    pub const WEST: Self = Self(0x0f0f_0f0f_0f0f_0f0f);
 
     /// The eastern half of the board.
     ///
@@ -808,7 +808,7 @@ impl Bitboard {
     /// // . . . . 1 1 1 1
     /// // . . . . 1 1 1 1
     /// ```
-    pub const EAST: Bitboard = Bitboard(0xf0f0_f0f0_f0f0_f0f0);
+    pub const EAST: Self = Self(0xf0f0_f0f0_f0f0_f0f0);
 }
 
 /// Square masks.
@@ -856,20 +856,20 @@ impl Direction {
     #[inline(always)]
     pub const fn offset(self) -> i32 {
         match self {
-            Direction::NorthWest => 7,
-            Direction::SouthWest => -9,
-            Direction::NorthEast => 9,
-            Direction::SouthEast => -7,
+            Self::NorthWest => 7,
+            Self::SouthWest => -9,
+            Self::NorthEast => 9,
+            Self::SouthEast => -7,
         }
     }
 
     #[inline(always)]
     pub const fn translate(self, bitboard: Bitboard) -> Bitboard {
         Bitboard(match self {
-            Direction::NorthWest => (bitboard.0 & !FILES[0]) << 7,
-            Direction::SouthWest => (bitboard.0 & !FILES[0]) >> 9,
-            Direction::NorthEast => (bitboard.0 & !FILES[7]) << 9,
-            Direction::SouthEast => (bitboard.0 & !FILES[7]) >> 7,
+            Self::NorthWest => (bitboard.0 & !FILES[0]) << 7,
+            Self::SouthWest => (bitboard.0 & !FILES[0]) >> 9,
+            Self::NorthEast => (bitboard.0 & !FILES[7]) << 9,
+            Self::SouthEast => (bitboard.0 & !FILES[7]) >> 7,
         })
     }
 }
@@ -914,117 +914,117 @@ impl fmt::Binary for Bitboard {
 
 impl From<Square> for Bitboard {
     #[inline]
-    fn from(sq: Square) -> Bitboard {
-        Bitboard::from_square(sq)
+    fn from(sq: Square) -> Self {
+        Self::from_square(sq)
     }
 }
 
 impl From<Rank> for Bitboard {
     #[inline]
-    fn from(rank: Rank) -> Bitboard {
-        Bitboard::from_rank(rank)
+    fn from(rank: Rank) -> Self {
+        Self::from_rank(rank)
     }
 }
 
 impl From<File> for Bitboard {
     #[inline]
-    fn from(file: File) -> Bitboard {
-        Bitboard::from_file(file)
+    fn from(file: File) -> Self {
+        Self::from_file(file)
     }
 }
 
 impl From<u64> for Bitboard {
     #[inline]
-    fn from(bb: u64) -> Bitboard {
-        Bitboard(bb)
+    fn from(bb: u64) -> Self {
+        Self(bb)
     }
 }
 
 impl From<Bitboard> for u64 {
     #[inline]
-    fn from(bb: Bitboard) -> u64 {
+    fn from(bb: Bitboard) -> Self {
         bb.0
     }
 }
 
 impl<T> ops::BitAnd<T> for Bitboard
 where
-    T: Into<Bitboard>,
+    T: Into<Self>,
 {
-    type Output = Bitboard;
+    type Output = Self;
 
     #[inline]
-    fn bitand(self, rhs: T) -> Bitboard {
-        let Bitboard(rhs) = rhs.into();
-        Bitboard(self.0 & rhs)
+    fn bitand(self, rhs: T) -> Self {
+        let Self(rhs) = rhs.into();
+        Self(self.0 & rhs)
     }
 }
 
 impl<T> ops::BitAndAssign<T> for Bitboard
 where
-    T: Into<Bitboard>,
+    T: Into<Self>,
 {
     #[inline]
     fn bitand_assign(&mut self, rhs: T) {
-        let Bitboard(rhs) = rhs.into();
+        let Self(rhs) = rhs.into();
         self.0 &= rhs;
     }
 }
 
 impl<T> ops::BitOr<T> for Bitboard
 where
-    T: Into<Bitboard>,
+    T: Into<Self>,
 {
-    type Output = Bitboard;
+    type Output = Self;
 
     #[inline]
-    fn bitor(self, rhs: T) -> Bitboard {
-        let Bitboard(rhs) = rhs.into();
-        Bitboard(self.0 | rhs)
+    fn bitor(self, rhs: T) -> Self {
+        let Self(rhs) = rhs.into();
+        Self(self.0 | rhs)
     }
 }
 
 impl<T> ops::BitOrAssign<T> for Bitboard
 where
-    T: Into<Bitboard>,
+    T: Into<Self>,
 {
     #[inline]
     fn bitor_assign(&mut self, rhs: T) {
-        let Bitboard(rhs) = rhs.into();
+        let Self(rhs) = rhs.into();
         self.0 |= rhs;
     }
 }
 
 impl<T> ops::BitXor<T> for Bitboard
 where
-    T: Into<Bitboard>,
+    T: Into<Self>,
 {
-    type Output = Bitboard;
+    type Output = Self;
 
     #[inline]
-    fn bitxor(self, rhs: T) -> Bitboard {
-        let Bitboard(rhs) = rhs.into();
-        Bitboard(self.0 ^ rhs)
+    fn bitxor(self, rhs: T) -> Self {
+        let Self(rhs) = rhs.into();
+        Self(self.0 ^ rhs)
     }
 }
 
 impl<T> ops::BitXorAssign<T> for Bitboard
 where
-    T: Into<Bitboard>,
+    T: Into<Self>,
 {
     #[inline]
     fn bitxor_assign(&mut self, rhs: T) {
-        let Bitboard(rhs) = rhs.into();
+        let Self(rhs) = rhs.into();
         self.0 ^= rhs;
     }
 }
 
 impl ops::Not for Bitboard {
-    type Output = Bitboard;
+    type Output = Self;
 
     #[inline]
-    fn not(self) -> Bitboard {
-        Bitboard(!self.0)
+    fn not(self) -> Self {
+        Self(!self.0)
     }
 }
 
@@ -1033,7 +1033,7 @@ impl FromIterator<Square> for Bitboard {
     where
         T: IntoIterator<Item = Square>,
     {
-        let mut result = Bitboard(0);
+        let mut result = Self(0);
         result.extend(iter);
         result
     }

--- a/src/board.rs
+++ b/src/board.rs
@@ -51,8 +51,8 @@ pub struct Board {
 }
 
 impl Board {
-    pub const fn new() -> Board {
-        Board {
+    pub const fn new() -> Self {
+        Self {
             by_role: ByRole {
                 pawn: Bitboard(0x00ff_0000_0000_ff00),
                 knight: Bitboard(0x4200_0000_0000_0042),
@@ -69,8 +69,8 @@ impl Board {
         }
     }
 
-    pub const fn empty() -> Board {
-        Board {
+    pub const fn empty() -> Self {
+        Self {
             by_role: ByRole {
                 pawn: Bitboard::EMPTY,
                 knight: Bitboard::EMPTY,
@@ -92,7 +92,7 @@ impl Board {
     /// # Panics
     ///
     /// Panics if the bitboards are inconsistent.
-    pub fn from_bitboards(by_role: ByRole<Bitboard>, by_color: ByColor<Bitboard>) -> Board {
+    pub fn from_bitboards(by_role: ByRole<Bitboard>, by_color: ByColor<Bitboard>) -> Self {
         let mut occupied = Bitboard::EMPTY;
         by_role.for_each(|role| {
             assert!(occupied.is_disjoint(role), "by_role not disjoint");
@@ -107,7 +107,7 @@ impl Board {
             by_color.black | by_color.white,
             "by_role does not match by_color"
         );
-        Board {
+        Self {
             by_role,
             by_color,
             occupied,
@@ -120,8 +120,8 @@ impl Board {
 
     #[cfg(feature = "variant")]
     #[cfg_attr(docs_rs, doc(cfg(feature = "variant")))]
-    pub const fn racing_kings() -> Board {
-        Board {
+    pub const fn racing_kings() -> Self {
+        Self {
             by_role: ByRole {
                 pawn: Bitboard(0x0000),
                 knight: Bitboard(0x1818),
@@ -140,8 +140,8 @@ impl Board {
 
     #[cfg(feature = "variant")]
     #[cfg_attr(docs_rs, doc(cfg(feature = "variant")))]
-    pub const fn horde() -> Board {
-        Board {
+    pub const fn horde() -> Self {
+        Self {
             by_role: ByRole {
                 pawn: Bitboard(0x00ff_0066_ffff_ffff),
                 knight: Bitboard(0x4200_0000_0000_0000),
@@ -206,14 +206,21 @@ impl Board {
     /// Bishops, rooks and queens.
     #[inline]
     pub const fn sliders(&self) -> Bitboard {
-        let ByRole { bishop, rook, queen, .. } = self.by_role;
+        let ByRole {
+            bishop,
+            rook,
+            queen,
+            ..
+        } = self.by_role;
         bishop.toggled_const(rook).toggled_const(queen)
     }
 
     /// Pawns, knights and kings.
     #[inline]
     pub const fn steppers(&self) -> Bitboard {
-        let ByRole { pawn, knight, king, .. } = self.by_role;
+        let ByRole {
+            pawn, knight, king, ..
+        } = self.by_role;
         pawn.toggled_const(knight).toggled_const(king)
     }
 
@@ -231,7 +238,10 @@ impl Board {
     /// The (unique!) king of the given side, if any.
     #[inline]
     pub const fn king_of(&self, color: Color) -> Option<Square> {
-        self.by_role.king.intersect(self.by_color(color)).single_square()
+        self.by_role
+            .king
+            .intersect(self.by_color(color))
+            .single_square()
     }
 
     #[inline]
@@ -295,7 +305,8 @@ impl Board {
 
     #[inline]
     pub const fn by_piece(&self, piece: Piece) -> Bitboard {
-        self.by_color(piece.color).intersect(self.by_role(piece.role))
+        self.by_color(piece.color)
+            .intersect(self.by_role(piece.role))
     }
 
     pub fn attacks_from(&self, sq: Square) -> Bitboard {
@@ -388,7 +399,7 @@ impl Board {
 
 impl Default for Board {
     fn default() -> Self {
-        Board::new()
+        Self::new()
     }
 }
 
@@ -419,7 +430,7 @@ impl FromIterator<(Square, Piece)> for Board {
     where
         T: IntoIterator<Item = (Square, Piece)>,
     {
-        let mut board = Board::empty();
+        let mut board = Self::empty();
         board.extend(iter);
         board
     }

--- a/src/board.rs
+++ b/src/board.rs
@@ -51,7 +51,7 @@ pub struct Board {
 }
 
 impl Board {
-    pub fn new() -> Board {
+    pub const fn new() -> Board {
         Board {
             by_role: ByRole {
                 pawn: Bitboard(0x00ff_0000_0000_ff00),
@@ -69,10 +69,20 @@ impl Board {
         }
     }
 
-    pub fn empty() -> Board {
+    pub const fn empty() -> Board {
         Board {
-            by_role: ByRole::default(),
-            by_color: ByColor::default(),
+            by_role: ByRole {
+                pawn: Bitboard::EMPTY,
+                knight: Bitboard::EMPTY,
+                bishop: Bitboard::EMPTY,
+                rook: Bitboard::EMPTY,
+                queen: Bitboard::EMPTY,
+                king: Bitboard::EMPTY,
+            },
+            by_color: ByColor {
+                white: Bitboard::EMPTY,
+                black: Bitboard::EMPTY,
+            },
             occupied: Bitboard::EMPTY,
         }
     }
@@ -88,18 +98,29 @@ impl Board {
             assert!(occupied.is_disjoint(role), "by_role not disjoint");
             occupied |= role;
         });
-        assert!(by_color.black.is_disjoint(by_color.white), "by_color not disjoint");
-        assert_eq!(occupied, by_color.black | by_color.white, "by_role does not match by_color");
-        Board { by_role, by_color, occupied }
+        assert!(
+            by_color.black.is_disjoint(by_color.white),
+            "by_color not disjoint"
+        );
+        assert_eq!(
+            occupied,
+            by_color.black | by_color.white,
+            "by_role does not match by_color"
+        );
+        Board {
+            by_role,
+            by_color,
+            occupied,
+        }
     }
 
-    pub fn into_bitboards(self) -> (ByRole<Bitboard>, ByColor<Bitboard>) {
+    pub const fn into_bitboards(self) -> (ByRole<Bitboard>, ByColor<Bitboard>) {
         (self.by_role, self.by_color)
     }
 
     #[cfg(feature = "variant")]
     #[cfg_attr(docs_rs, doc(cfg(feature = "variant")))]
-    pub fn racing_kings() -> Board {
+    pub const fn racing_kings() -> Board {
         Board {
             by_role: ByRole {
                 pawn: Bitboard(0x0000),
@@ -119,7 +140,7 @@ impl Board {
 
     #[cfg(feature = "variant")]
     #[cfg_attr(docs_rs, doc(cfg(feature = "variant")))]
-    pub fn horde() -> Board {
+    pub const fn horde() -> Board {
         Board {
             by_role: ByRole {
                 pawn: Bitboard(0x00ff_0066_ffff_ffff),
@@ -138,68 +159,79 @@ impl Board {
     }
 
     #[inline]
-    pub fn occupied(&self) -> Bitboard {
+    pub const fn occupied(&self) -> Bitboard {
         self.occupied
     }
 
     #[inline]
-    pub fn pawns(&self) -> Bitboard {
+    pub const fn pawns(&self) -> Bitboard {
         self.by_role.pawn
     }
+
     #[inline]
-    pub fn knights(&self) -> Bitboard {
+    pub const fn knights(&self) -> Bitboard {
         self.by_role.knight
     }
+
     #[inline]
-    pub fn bishops(&self) -> Bitboard {
+    pub const fn bishops(&self) -> Bitboard {
         self.by_role.bishop
     }
+
     #[inline]
-    pub fn rooks(&self) -> Bitboard {
+    pub const fn rooks(&self) -> Bitboard {
         self.by_role.rook
     }
+
     #[inline]
-    pub fn queens(&self) -> Bitboard {
+    pub const fn queens(&self) -> Bitboard {
         self.by_role.queen
     }
+
     #[inline]
-    pub fn kings(&self) -> Bitboard {
+    pub const fn kings(&self) -> Bitboard {
         self.by_role.king
     }
 
     #[inline]
-    pub fn white(&self) -> Bitboard {
+    pub const fn white(&self) -> Bitboard {
         self.by_color.white
     }
+
     #[inline]
-    pub fn black(&self) -> Bitboard {
+    pub const fn black(&self) -> Bitboard {
         self.by_color.black
     }
 
     /// Bishops, rooks and queens.
     #[inline]
-    pub fn sliders(&self) -> Bitboard {
-        self.by_role.bishop ^ self.by_role.rook ^ self.by_role.queen
+    pub const fn sliders(&self) -> Bitboard {
+        let ByRole { bishop, rook, queen, .. } = self.by_role;
+        bishop.toggled_const(rook).toggled_const(queen)
     }
+
     /// Pawns, knights and kings.
     #[inline]
-    pub fn steppers(&self) -> Bitboard {
-        self.by_role.pawn ^ self.by_role.knight ^ self.by_role.king
+    pub const fn steppers(&self) -> Bitboard {
+        let ByRole { pawn, knight, king, .. } = self.by_role;
+        pawn.toggled_const(knight).toggled_const(king)
     }
 
     #[inline]
-    pub fn rooks_and_queens(&self) -> Bitboard {
-        self.by_role.rook ^ self.by_role.queen
+    pub const fn rooks_and_queens(&self) -> Bitboard {
+        let ByRole { rook, queen, .. } = self.by_role;
+        rook.toggled_const(queen)
     }
     #[inline]
-    pub fn bishops_and_queens(&self) -> Bitboard {
-        self.by_role.bishop ^ self.by_role.queen
+    pub const fn bishops_and_queens(&self) -> Bitboard {
+        let ByRole { bishop, queen, .. } = self.by_role;
+        bishop.toggled_const(queen)
     }
 
     /// The (unique!) king of the given side, if any.
     #[inline]
-    pub fn king_of(&self, color: Color) -> Option<Square> {
-        (self.by_role.king & self.by_color(color)).single_square()
+    pub const fn king_of(&self, color: Color) -> Option<Square> {
+        self.by_role.king.intersect(self.by_color(color)).single_square()
     }
 
     #[inline]
@@ -209,10 +241,10 @@ impl Board {
 
     #[inline]
     pub fn role_at(&self, sq: Square) -> Option<Role> {
-        if !self.occupied.contains(sq) {
-            None // catch early
-        } else {
+        if self.occupied.contains(sq) {
             self.by_role.find(|r| r.contains(sq))
+        } else {
+            None // catch early
         }
     }
 
@@ -252,18 +284,18 @@ impl Board {
     }
 
     #[inline]
-    pub fn by_color(&self, color: Color) -> Bitboard {
+    pub const fn by_color(&self, color: Color) -> Bitboard {
         *self.by_color.get(color)
     }
 
     #[inline]
-    pub fn by_role(&self, role: Role) -> Bitboard {
+    pub const fn by_role(&self, role: Role) -> Bitboard {
         *self.by_role.get(role)
     }
 
     #[inline]
-    pub fn by_piece(&self, piece: Piece) -> Bitboard {
-        self.by_color(piece.color) & self.by_role(piece.role)
+    pub const fn by_piece(&self, piece: Piece) -> Bitboard {
+        self.by_color(piece.color).intersect(self.by_role(piece.role))
     }
 
     pub fn attacks_from(&self, sq: Square) -> Bitboard {
@@ -279,7 +311,7 @@ impl Board {
                 | (attacks::bishop_attacks(sq, occupied) & self.bishops_and_queens())
                 | (attacks::knight_attacks(sq) & self.by_role.knight)
                 | (attacks::king_attacks(sq) & self.by_role.king)
-                | (attacks::pawn_attacks(!attacker, sq) & self.by_role.pawn))
+                | (attacks::pawn_attacks(attacker.other(), sq) & self.by_role.pawn))
     }
 
     pub fn material_side(&self, color: Color) -> ByRole<u8> {

--- a/src/color.rs
+++ b/src/color.rs
@@ -33,10 +33,10 @@ pub enum Color {
 }
 
 impl Color {
-    pub const fn from_char(ch: char) -> Option<Color> {
+    pub const fn from_char(ch: char) -> Option<Self> {
         Some(match ch {
-            'w' => Color::White,
-            'b' => Color::Black,
+            'w' => Self::White,
+            'b' => Self::Black,
             _ => return None,
         })
     }
@@ -45,10 +45,10 @@ impl Color {
         self.fold_wb('w', 'b')
     }
 
-    fn from_name(name: &str) -> Option<Color> {
+    fn from_name(name: &str) -> Option<Self> {
         Some(match name {
-            "white" => Color::White,
-            "black" => Color::Black,
+            "white" => Self::White,
+            "black" => Self::Black,
             _ => return None,
         })
     }
@@ -61,42 +61,42 @@ impl Color {
     }
 
     #[inline]
-    pub const fn from_white(white: bool) -> Color {
+    pub const fn from_white(white: bool) -> Self {
         if white {
-            Color::White
+            Self::White
         } else {
-            Color::Black
+            Self::Black
         }
     }
 
     #[inline]
-    pub const fn from_black(black: bool) -> Color {
+    pub const fn from_black(black: bool) -> Self {
         if black {
-            Color::Black
+            Self::Black
         } else {
-            Color::White
+            Self::White
         }
     }
 
     #[inline]
     pub fn fold_wb<T>(self, white: T, black: T) -> T {
         match self {
-            Color::White => white,
-            Color::Black => black,
+            Self::White => white,
+            Self::Black => black,
         }
     }
 
     #[inline]
     pub const fn is_white(self) -> bool {
-        matches!(self, Color::White)
+        matches!(self, Self::White)
     }
     #[inline]
     pub const fn is_black(self) -> bool {
-        matches!(self, Color::Black)
+        matches!(self, Self::Black)
     }
 
     /// Same as the NOT (`!`) operator, but usable in `const` contexts.
-    pub const fn other(self) -> Color {
+    pub const fn other(self) -> Self {
         match self {
             Self::White => Self::Black,
             Self::Black => Self::White,
@@ -114,8 +114,8 @@ impl Color {
     #[inline]
     pub fn relative_rank(self, rank: Rank) -> Rank {
         match self {
-            Color::White => rank,
-            Color::Black => rank.flip_vertical(),
+            Self::White => rank,
+            Self::Black => rank.flip_vertical(),
         }
     }
 
@@ -150,24 +150,24 @@ impl Color {
     }
 
     /// `White` and `Black`, in this order.
-    pub const ALL: [Color; 2] = [Color::White, Color::Black];
+    pub const ALL: [Self; 2] = [Self::White, Self::Black];
 }
 
 impl ops::Not for Color {
-    type Output = Color;
+    type Output = Self;
 
     #[inline]
-    fn not(self) -> Color {
-        self.fold_wb(Color::Black, Color::White)
+    fn not(self) -> Self::Output {
+        self.fold_wb(Self::Black, Self::White)
     }
 }
 
 impl ops::BitXor<bool> for Color {
-    type Output = Color;
+    type Output = Self;
 
     #[inline]
-    fn bitxor(self, flip: bool) -> Color {
-        Color::from_white(self.is_white() ^ flip)
+    fn bitxor(self, flip: bool) -> Self::Output {
+        Self::from_white(self.is_white() ^ flip)
     }
 }
 
@@ -193,8 +193,8 @@ impl std::error::Error for ParseColorError {}
 impl FromStr for Color {
     type Err = ParseColorError;
 
-    fn from_str(s: &str) -> Result<Color, ParseColorError> {
-        Color::from_name(s).ok_or(ParseColorError)
+    fn from_str(s: &str) -> Result<Self, ParseColorError> {
+        Self::from_name(s).ok_or(ParseColorError)
     }
 }
 
@@ -208,11 +208,11 @@ pub struct ByColor<T> {
 
 impl<T> ByColor<T> {
     #[inline]
-    pub fn new_with<F>(mut init: F) -> ByColor<T>
+    pub fn new_with<F>(mut init: F) -> Self
     where
         F: FnMut(Color) -> T,
     {
-        ByColor {
+        Self {
             white: init(Color::White),
             black: init(Color::Black),
         }
@@ -221,17 +221,13 @@ impl<T> ByColor<T> {
     #[inline]
     pub const fn get(&self, color: Color) -> &T {
         // Safety: Trivial offset into #[repr(C)] struct.
-        unsafe {
-            &*(self as *const ByColor<T>)
-                .cast::<T>()
-                .offset(color as isize)
-        }
+        unsafe { &*(self as *const Self).cast::<T>().offset(color as isize) }
     }
 
     #[inline]
     pub fn get_mut(&mut self, color: Color) -> &mut T {
         // Safety: Trivial offset into #[repr(C)] struct.
-        unsafe { &mut *(self as *mut ByColor<T>).cast::<T>().offset(color as isize) }
+        unsafe { &mut *(self as *mut Self).cast::<T>().offset(color as isize) }
     }
 
     pub fn flip(&mut self) {
@@ -239,8 +235,8 @@ impl<T> ByColor<T> {
     }
 
     #[must_use]
-    pub fn into_flipped(self) -> ByColor<T> {
-        ByColor {
+    pub fn into_flipped(self) -> Self {
+        Self {
             black: self.white,
             white: self.black,
         }
@@ -341,7 +337,7 @@ impl<T: PartialOrd> ByColor<T> {
     }
 
     #[must_use]
-    pub fn into_normalized(mut self) -> ByColor<T> {
+    pub fn into_normalized(mut self) -> Self {
         self.normalize();
         self
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -33,7 +33,7 @@ pub enum Color {
 }
 
 impl Color {
-    pub fn from_char(ch: char) -> Option<Color> {
+    pub const fn from_char(ch: char) -> Option<Color> {
         Some(match ch {
             'w' => Color::White,
             'b' => Color::Black,
@@ -53,12 +53,15 @@ impl Color {
         })
     }
 
-    fn name(self) -> &'static str {
-        self.fold_wb("white", "black")
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Black => "black",
+            Self::White => "white",
+        }
     }
 
     #[inline]
-    pub fn from_white(white: bool) -> Color {
+    pub const fn from_white(white: bool) -> Color {
         if white {
             Color::White
         } else {
@@ -67,7 +70,7 @@ impl Color {
     }
 
     #[inline]
-    pub fn from_black(black: bool) -> Color {
+    pub const fn from_black(black: bool) -> Color {
         if black {
             Color::Black
         } else {
@@ -84,17 +87,28 @@ impl Color {
     }
 
     #[inline]
-    pub fn is_white(self) -> bool {
-        self == Color::White
+    pub const fn is_white(self) -> bool {
+        matches!(self, Color::White)
     }
     #[inline]
-    pub fn is_black(self) -> bool {
-        self == Color::Black
+    pub const fn is_black(self) -> bool {
+        matches!(self, Color::Black)
+    }
+
+    /// Same as the NOT (`!`) operator, but usable in `const` contexts.
+    pub const fn other(self) -> Color {
+        match self {
+            Self::White => Self::Black,
+            Self::Black => Self::White,
+        }
     }
 
     #[inline]
-    pub fn backrank(self) -> Rank {
-        self.fold_wb(Rank::First, Rank::Eighth)
+    pub const fn backrank(self) -> Rank {
+        match self {
+            Self::White => Rank::First,
+            Self::Black => Rank::Eighth,
+        }
     }
 
     #[inline]
@@ -106,27 +120,32 @@ impl Color {
     }
 
     #[inline]
-    pub fn pawn(self) -> Piece {
+    pub const fn pawn(self) -> Piece {
         Role::Pawn.of(self)
     }
+
     #[inline]
-    pub fn knight(self) -> Piece {
+    pub const fn knight(self) -> Piece {
         Role::Knight.of(self)
     }
+
     #[inline]
-    pub fn bishop(self) -> Piece {
+    pub const fn bishop(self) -> Piece {
         Role::Bishop.of(self)
     }
+
     #[inline]
-    pub fn rook(self) -> Piece {
+    pub const fn rook(self) -> Piece {
         Role::Rook.of(self)
     }
+
     #[inline]
-    pub fn queen(self) -> Piece {
+    pub const fn queen(self) -> Piece {
         Role::Queen.of(self)
     }
+
     #[inline]
-    pub fn king(self) -> Piece {
+    pub const fn king(self) -> Piece {
         Role::King.of(self)
     }
 
@@ -200,7 +219,7 @@ impl<T> ByColor<T> {
     }
 
     #[inline]
-    pub fn get(&self, color: Color) -> &T {
+    pub const fn get(&self, color: Color) -> &T {
         // Safety: Trivial offset into #[repr(C)] struct.
         unsafe {
             &*(self as *const ByColor<T>)
@@ -262,7 +281,7 @@ impl<T> ByColor<T> {
     }
 
     #[inline]
-    pub fn as_ref(&self) -> ByColor<&T> {
+    pub const fn as_ref(&self) -> ByColor<&T> {
         ByColor {
             black: &self.black,
             white: &self.white,
@@ -298,7 +317,7 @@ impl<T> ByColor<T> {
 }
 
 impl<T> ByColor<ByRole<T>> {
-    pub fn piece(&self, piece: Piece) -> &T {
+    pub const fn piece(&self, piece: Piece) -> &T {
         self.get(piece.color).get(piece.role)
     }
 

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -170,15 +170,15 @@ pub enum ParseFenError {
 impl Display for ParseFenError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match *self {
-            ParseFenError::InvalidFen => "invalid fen",
-            ParseFenError::InvalidBoard => "invalid board part in fen",
-            ParseFenError::InvalidPocket => "invalid pocket in fen",
-            ParseFenError::InvalidTurn => "invalid turn part in fen",
-            ParseFenError::InvalidCastling => "invalid castling part in fen",
-            ParseFenError::InvalidEpSquare => "invalid ep square in fen",
-            ParseFenError::InvalidRemainingChecks => "invalid remaining checks in fen",
-            ParseFenError::InvalidHalfmoveClock => "invalid halfmove clock in fen",
-            ParseFenError::InvalidFullmoves => "invalid fullmove part in fen",
+            Self::InvalidFen => "invalid fen",
+            Self::InvalidBoard => "invalid board part in fen",
+            Self::InvalidPocket => "invalid pocket in fen",
+            Self::InvalidTurn => "invalid turn part in fen",
+            Self::InvalidCastling => "invalid castling part in fen",
+            Self::InvalidEpSquare => "invalid ep square in fen",
+            Self::InvalidRemainingChecks => "invalid remaining checks in fen",
+            Self::InvalidHalfmoveClock => "invalid halfmove clock in fen",
+            Self::InvalidFullmoves => "invalid fullmove part in fen",
         })
     }
 }
@@ -266,7 +266,7 @@ fn parse_pockets(s: &[u8]) -> Option<ByColor<ByRole<u8>>> {
 }
 
 impl Board {
-    pub fn from_ascii_board_fen(board_fen: &[u8]) -> Result<Board, ParseFenError> {
+    pub fn from_ascii_board_fen(board_fen: &[u8]) -> Result<Self, ParseFenError> {
         Ok(parse_board_fen(board_fen)?.0)
     }
 
@@ -298,8 +298,8 @@ impl Board {
 impl FromStr for Board {
     type Err = ParseFenError;
 
-    fn from_str(board_fen: &str) -> Result<Board, ParseFenError> {
-        Board::from_ascii_board_fen(board_fen.as_bytes())
+    fn from_str(board_fen: &str) -> Result<Self, ParseFenError> {
+        Self::from_ascii_board_fen(board_fen.as_bytes())
     }
 }
 
@@ -363,8 +363,8 @@ pub struct Fen(pub Setup);
 
 impl Fen {
     /// The FEN of the empty position `8/8/8/8/8/8/8/8 w - - 0 1`.
-    pub const fn empty() -> Fen {
-        Fen(Setup::empty())
+    pub const fn empty() -> Self {
+        Self(Setup::empty())
     }
 
     /// Parses a FEN or EPD.
@@ -385,7 +385,7 @@ impl Fen {
     /// assert_eq!(fen, Fen::default());
     /// # Ok::<_, shakmaty::fen::ParseFenError>(())
     /// ```
-    pub fn from_ascii(fen: &[u8]) -> Result<Fen, ParseFenError> {
+    pub fn from_ascii(fen: &[u8]) -> Result<Self, ParseFenError> {
         let mut result = Setup::empty();
         let mut parts = fen
             .split(|ch| *ch == b' ' || *ch == b'_')
@@ -512,16 +512,16 @@ impl Fen {
         if last_part.is_some() {
             Err(ParseFenError::InvalidFen)
         } else {
-            Ok(Fen(result))
+            Ok(Self(result))
         }
     }
 
-    pub const fn from_setup(setup: Setup) -> Fen {
-        Fen(setup)
+    pub const fn from_setup(setup: Setup) -> Self {
+        Self(setup)
     }
 
-    pub fn from_position<P: Position>(pos: P, mode: EnPassantMode) -> Fen {
-        Fen(pos.into_setup(mode))
+    pub fn from_position<P: Position>(pos: P, mode: EnPassantMode) -> Self {
+        Self(pos.into_setup(mode))
     }
 
     pub const fn as_setup(&self) -> &Setup {
@@ -544,13 +544,13 @@ impl Fen {
 }
 
 impl From<Setup> for Fen {
-    fn from(setup: Setup) -> Fen {
-        Fen::from_setup(setup)
+    fn from(setup: Setup) -> Self {
+        Self::from_setup(setup)
     }
 }
 
 impl From<Fen> for Setup {
-    fn from(fen: Fen) -> Setup {
+    fn from(fen: Fen) -> Self {
         fen.into_setup()
     }
 }
@@ -558,8 +558,8 @@ impl From<Fen> for Setup {
 impl FromStr for Fen {
     type Err = ParseFenError;
 
-    fn from_str(fen: &str) -> Result<Fen, ParseFenError> {
-        Fen::from_ascii(fen.as_bytes())
+    fn from_str(fen: &str) -> Result<Self, ParseFenError> {
+        Self::from_ascii(fen.as_bytes())
     }
 }
 
@@ -575,25 +575,25 @@ impl Display for Fen {
 pub struct Epd(Setup);
 
 impl Epd {
-    pub const fn empty() -> Epd {
-        Epd(Setup::empty())
+    pub const fn empty() -> Self {
+        Self(Setup::empty())
     }
 
-    pub fn from_ascii(epd: &[u8]) -> Result<Epd, ParseFenError> {
-        Ok(Epd::from_setup(Fen::from_ascii(epd)?.into_setup()))
+    pub fn from_ascii(epd: &[u8]) -> Result<Self, ParseFenError> {
+        Ok(Self::from_setup(Fen::from_ascii(epd)?.into_setup()))
     }
 
-    pub const fn from_setup(mut setup: Setup) -> Epd {
+    pub const fn from_setup(mut setup: Setup) -> Self {
         setup.halfmoves = 0;
         setup.fullmoves = match NonZeroU32::new(1) {
             Some(num) => num,
             _ => unreachable!(),
         };
-        Epd(setup)
+        Self(setup)
     }
 
-    pub fn from_position<P: Position>(pos: P, mode: EnPassantMode) -> Epd {
-        Epd::from_setup(pos.into_setup(mode))
+    pub fn from_position<P: Position>(pos: P, mode: EnPassantMode) -> Self {
+        Self::from_setup(pos.into_setup(mode))
     }
 
     pub const fn as_setup(&self) -> &Setup {
@@ -610,13 +610,13 @@ impl Epd {
 }
 
 impl From<Setup> for Epd {
-    fn from(setup: Setup) -> Epd {
-        Epd::from_setup(setup)
+    fn from(setup: Setup) -> Self {
+        Self::from_setup(setup)
     }
 }
 
 impl From<Epd> for Setup {
-    fn from(epd: Epd) -> Setup {
+    fn from(epd: Epd) -> Self {
         epd.into_setup()
     }
 }
@@ -624,8 +624,8 @@ impl From<Epd> for Setup {
 impl FromStr for Epd {
     type Err = ParseFenError;
 
-    fn from_str(epd: &str) -> Result<Epd, ParseFenError> {
-        Epd::from_ascii(epd.as_bytes())
+    fn from_str(epd: &str) -> Result<Self, ParseFenError> {
+        Self::from_ascii(epd.as_bytes())
     }
 }
 

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -276,7 +276,7 @@ impl Board {
     /// Promoted pieces are marked like `Q~`.
     ///
     /// Returns a `struct` that implements [`Display`].
-    pub fn display_with_promotions(&self, promoted: Bitboard) -> BoardDisplayer<'_> {
+    pub const fn display_with_promotions(&self, promoted: Bitboard) -> BoardDisplayer<'_> {
         BoardDisplayer {
             board: self,
             promoted,
@@ -363,7 +363,7 @@ pub struct Fen(pub Setup);
 
 impl Fen {
     /// The FEN of the empty position `8/8/8/8/8/8/8/8 w - - 0 1`.
-    pub fn empty() -> Fen {
+    pub const fn empty() -> Fen {
         Fen(Setup::empty())
     }
 
@@ -516,7 +516,7 @@ impl Fen {
         }
     }
 
-    pub fn from_setup(setup: Setup) -> Fen {
+    pub const fn from_setup(setup: Setup) -> Fen {
         Fen(setup)
     }
 
@@ -524,11 +524,11 @@ impl Fen {
         Fen(pos.into_setup(mode))
     }
 
-    pub fn as_setup(&self) -> &Setup {
+    pub const fn as_setup(&self) -> &Setup {
         &self.0
     }
 
-    pub fn into_setup(self) -> Setup {
+    pub const fn into_setup(self) -> Setup {
         self.0
     }
 
@@ -575,7 +575,7 @@ impl Display for Fen {
 pub struct Epd(Setup);
 
 impl Epd {
-    pub fn empty() -> Epd {
+    pub const fn empty() -> Epd {
         Epd(Setup::empty())
     }
 
@@ -583,9 +583,12 @@ impl Epd {
         Ok(Epd::from_setup(Fen::from_ascii(epd)?.into_setup()))
     }
 
-    pub fn from_setup(mut setup: Setup) -> Epd {
+    pub const fn from_setup(mut setup: Setup) -> Epd {
         setup.halfmoves = 0;
-        setup.fullmoves = NonZeroU32::new(1).unwrap();
+        setup.fullmoves = match NonZeroU32::new(1) {
+            Some(num) => num,
+            _ => unreachable!(),
+        };
         Epd(setup)
     }
 
@@ -593,11 +596,11 @@ impl Epd {
         Epd::from_setup(pos.into_setup(mode))
     }
 
-    pub fn as_setup(&self) -> &Setup {
+    pub const fn as_setup(&self) -> &Setup {
         &self.0
     }
 
-    pub fn into_setup(self) -> Setup {
+    pub const fn into_setup(self) -> Setup {
         self.0
     }
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -40,25 +40,25 @@ pub enum Outcome {
 }
 
 impl Outcome {
-    pub const fn from_winner(winner: Option<Color>) -> Outcome {
+    pub const fn from_winner(winner: Option<Color>) -> Self {
         match winner {
-            Some(winner) => Outcome::Decisive { winner },
-            None => Outcome::Draw,
+            Some(winner) => Self::Decisive { winner },
+            None => Self::Draw,
         }
     }
 
     pub const fn winner(self) -> Option<Color> {
         match self {
-            Outcome::Decisive { winner } => Some(winner),
-            Outcome::Draw => None,
+            Self::Decisive { winner } => Some(winner),
+            Self::Draw => None,
         }
     }
 
-    pub const fn from_ascii(bytes: &[u8]) -> Result<Outcome, ParseOutcomeError> {
+    pub const fn from_ascii(bytes: &[u8]) -> Result<Self, ParseOutcomeError> {
         Ok(match bytes {
-            b"1-0" => Outcome::Decisive { winner: White },
-            b"0-1" => Outcome::Decisive { winner: Black },
-            b"1/2-1/2" => Outcome::Draw,
+            b"1-0" => Self::Decisive { winner: White },
+            b"0-1" => Self::Decisive { winner: Black },
+            b"1/2-1/2" => Self::Draw,
             b"*" => return Err(ParseOutcomeError::Unknown),
             _ => return Err(ParseOutcomeError::Invalid),
         })
@@ -68,9 +68,9 @@ impl Outcome {
 impl fmt::Display for Outcome {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match *self {
-            Outcome::Decisive { winner: White } => "1-0",
-            Outcome::Decisive { winner: Black } => "0-1",
-            Outcome::Draw => "1/2-1/2",
+            Self::Decisive { winner: White } => "1-0",
+            Self::Decisive { winner: Black } => "0-1",
+            Self::Draw => "1/2-1/2",
         })
     }
 }
@@ -87,8 +87,8 @@ pub enum ParseOutcomeError {
 impl fmt::Display for ParseOutcomeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match *self {
-            ParseOutcomeError::Unknown => "unknown outcome: *",
-            ParseOutcomeError::Invalid => "invalid outcome",
+            Self::Unknown => "unknown outcome: *",
+            Self::Invalid => "invalid outcome",
         })
     }
 }
@@ -99,8 +99,8 @@ impl std::error::Error for ParseOutcomeError {}
 impl FromStr for Outcome {
     type Err = ParseOutcomeError;
 
-    fn from_str(s: &str) -> Result<Outcome, ParseOutcomeError> {
-        Outcome::from_ascii(s.as_bytes())
+    fn from_str(s: &str) -> Result<Self, ParseOutcomeError> {
+        Self::from_ascii(s.as_bytes())
     }
 }
 
@@ -199,7 +199,7 @@ impl<P> PositionError<P> {
     fn ignore(mut self, ignore: PositionErrorKinds) -> Result<P, Self> {
         self.errors -= ignore;
         match self {
-            PositionError { pos, errors } if errors.is_empty() => Ok(pos),
+            Self { pos, errors } if errors.is_empty() => Ok(pos),
             _ => Err(self),
         }
     }
@@ -647,7 +647,7 @@ impl Chess {
         setup: Setup,
         mode: CastlingMode,
     ) -> (
-        Chess,
+        Self,
         Option<ByColor<ByRole<u8>>>,
         Option<ByColor<RemainingChecks>>,
         PositionErrorKinds,
@@ -670,7 +670,7 @@ impl Chess {
             }
         };
 
-        let pos = Chess {
+        let pos = Self {
             board: setup.board,
             turn: setup.turn,
             castles,
@@ -685,8 +685,8 @@ impl Chess {
     }
 
     /// Initial position of any regular chess game.
-    pub const fn new() -> Chess {
-        Chess {
+    pub const fn new() -> Self {
+        Self {
             board: Board::new(),
             turn: White,
             castles: Castles::new(),
@@ -701,8 +701,8 @@ impl Chess {
 }
 
 impl Default for Chess {
-    fn default() -> Chess {
-        Chess::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -752,8 +752,8 @@ impl PartialEq for Chess {
 impl Eq for Chess {}
 
 impl FromSetup for Chess {
-    fn from_setup(setup: Setup, mode: CastlingMode) -> Result<Chess, PositionError<Chess>> {
-        let (pos, _, _, errors) = Chess::from_setup_unchecked(setup, mode);
+    fn from_setup(setup: Setup, mode: CastlingMode) -> Result<Self, PositionError<Self>> {
+        let (pos, _, _, errors) = Self::from_setup_unchecked(setup, mode);
         PositionError { pos, errors }.strict()
     }
 }
@@ -1037,13 +1037,13 @@ pub(crate) mod variant {
     }
 
     impl Default for Atomic {
-        fn default() -> Atomic {
+        fn default() -> Self {
             Self::new()
         }
     }
 
     impl FromSetup for Atomic {
-        fn from_setup(setup: Setup, mode: CastlingMode) -> Result<Atomic, PositionError<Atomic>> {
+        fn from_setup(setup: Setup, mode: CastlingMode) -> Result<Self, PositionError<Self>> {
             let mut errors = PositionErrorKinds::empty();
 
             let castles = match Castles::from_setup(&setup, mode) {
@@ -1062,7 +1062,7 @@ pub(crate) mod variant {
                 }
             };
 
-            let pos = Atomic {
+            let pos = Self {
                 board: setup.board,
                 turn: setup.turn,
                 castles,
@@ -1327,7 +1327,7 @@ pub(crate) mod variant {
     }
 
     impl Default for Antichess {
-        fn default() -> Antichess {
+        fn default() -> Self {
             Self::new()
         }
     }
@@ -1336,7 +1336,7 @@ pub(crate) mod variant {
         fn from_setup(
             setup: Setup,
             mode: CastlingMode,
-        ) -> Result<Antichess, PositionError<Antichess>> {
+        ) -> Result<Self, PositionError<Self>> {
             let mut errors = PositionErrorKinds::empty();
 
             let ep_square = match EnPassant::from_setup(&setup) {
@@ -1347,7 +1347,7 @@ pub(crate) mod variant {
                 }
             };
 
-            let pos = Antichess {
+            let pos = Self {
                 board: setup.board,
                 turn: setup.turn,
                 castles: Castles::empty(mode),
@@ -1526,7 +1526,7 @@ pub(crate) mod variant {
     }
 
     impl KingOfTheHill {
-        pub const fn new() -> KingOfTheHill {
+        pub const fn new() -> Self {
             Self {
                 chess: Chess::new(),
             }
@@ -1537,11 +1537,11 @@ pub(crate) mod variant {
         fn from_setup(
             setup: Setup,
             mode: CastlingMode,
-        ) -> Result<KingOfTheHill, PositionError<KingOfTheHill>> {
+        ) -> Result<Self, PositionError<Self>> {
             let (chess, _, _, errors) = Chess::from_setup_unchecked(setup, mode);
             PositionError {
                 errors,
-                pos: KingOfTheHill { chess },
+                pos: Self { chess },
             }
             .strict()
         }
@@ -1651,7 +1651,7 @@ pub(crate) mod variant {
     }
 
     impl ThreeCheck {
-        pub const fn new() -> ThreeCheck {
+        pub const fn new() -> Self {
             Self {
                 chess: Chess::new(),
                 remaining_checks: ByColor {
@@ -1666,7 +1666,7 @@ pub(crate) mod variant {
         fn from_setup(
             setup: Setup,
             mode: CastlingMode,
-        ) -> Result<ThreeCheck, PositionError<ThreeCheck>> {
+        ) -> Result<Self, PositionError<Self>> {
             let (chess, _, remaining_checks, mut errors) = Chess::from_setup_unchecked(setup, mode);
 
             let remaining_checks = remaining_checks.unwrap_or_default();
@@ -1676,7 +1676,7 @@ pub(crate) mod variant {
 
             PositionError {
                 errors,
-                pos: ThreeCheck {
+                pos: Self {
                     chess,
                     remaining_checks,
                 },
@@ -1801,7 +1801,7 @@ pub(crate) mod variant {
     }
 
     impl Crazyhouse {
-        pub const fn new() -> Crazyhouse {
+        pub const fn new() -> Self {
             Self {
                 chess: Chess::new(),
                 promoted: Bitboard::EMPTY,
@@ -1856,7 +1856,7 @@ pub(crate) mod variant {
         fn from_setup(
             setup: Setup,
             mode: CastlingMode,
-        ) -> Result<Crazyhouse, PositionError<Crazyhouse>> {
+        ) -> Result<Self, PositionError<Self>> {
             let promoted = setup.promoted
                 & setup.board.occupied()
                 & !setup.board.pawns()
@@ -1901,7 +1901,7 @@ pub(crate) mod variant {
 
             PositionError {
                 errors,
-                pos: Crazyhouse {
+                pos: Self {
                     chess,
                     promoted,
                     pockets,
@@ -2086,8 +2086,8 @@ pub(crate) mod variant {
     }
 
     impl RacingKings {
-        pub const fn new() -> RacingKings {
-            RacingKings {
+        pub const fn new() -> Self {
+            Self {
                 board: Board::racing_kings(),
                 turn: White,
                 castles: Castles::empty(CastlingMode::Standard),
@@ -2101,8 +2101,8 @@ pub(crate) mod variant {
     }
 
     impl Default for RacingKings {
-        fn default() -> RacingKings {
-            RacingKings::new()
+        fn default() -> Self {
+            Self::new()
         }
     }
 
@@ -2110,7 +2110,7 @@ pub(crate) mod variant {
         fn from_setup(
             setup: Setup,
             mode: CastlingMode,
-        ) -> Result<RacingKings, PositionError<RacingKings>> {
+        ) -> Result<Self, PositionError<Self>> {
             let mut errors = PositionErrorKinds::empty();
 
             if setup.castling_rights.any() {
@@ -2136,7 +2136,7 @@ pub(crate) mod variant {
                 errors |= PositionErrorKinds::INVALID_EP_SQUARE;
             }
 
-            let pos = RacingKings {
+            let pos = Self {
                 board: setup.board,
                 turn: setup.turn,
                 castles: Castles::empty(mode),
@@ -2315,11 +2315,11 @@ pub(crate) mod variant {
     }
 
     impl Default for Horde {
-        fn default() -> Horde {
+        fn default() -> Self {
             let mut castles = Castles::default();
             castles.discard_color(White);
 
-            Horde {
+            Self {
                 board: Board::horde(),
                 turn: White,
                 castles,
@@ -2331,7 +2331,7 @@ pub(crate) mod variant {
     }
 
     impl FromSetup for Horde {
-        fn from_setup(setup: Setup, mode: CastlingMode) -> Result<Horde, PositionError<Horde>> {
+        fn from_setup(setup: Setup, mode: CastlingMode) -> Result<Self, PositionError<Self>> {
             let mut errors = PositionErrorKinds::empty();
 
             let castles = match Castles::from_setup(&setup, mode) {
@@ -2350,7 +2350,7 @@ pub(crate) mod variant {
                 }
             };
 
-            let pos = Horde {
+            let pos = Self {
                 board: setup.board,
                 turn: setup.turn,
                 castles,

--- a/src/position.rs
+++ b/src/position.rs
@@ -40,21 +40,21 @@ pub enum Outcome {
 }
 
 impl Outcome {
-    pub fn from_winner(winner: Option<Color>) -> Outcome {
+    pub const fn from_winner(winner: Option<Color>) -> Outcome {
         match winner {
             Some(winner) => Outcome::Decisive { winner },
             None => Outcome::Draw,
         }
     }
 
-    pub fn winner(self) -> Option<Color> {
+    pub const fn winner(self) -> Option<Color> {
         match self {
             Outcome::Decisive { winner } => Some(winner),
             Outcome::Draw => None,
         }
     }
 
-    pub fn from_ascii(bytes: &[u8]) -> Result<Outcome, ParseOutcomeError> {
+    pub const fn from_ascii(bytes: &[u8]) -> Result<Outcome, ParseOutcomeError> {
         Ok(match bytes {
             b"1-0" => Outcome::Decisive { winner: White },
             b"0-1" => Outcome::Decisive { winner: Black },
@@ -683,18 +683,26 @@ impl Chess {
 
         (pos, setup.pockets, setup.remaining_checks, errors)
     }
+
+    /// Initial position of any regular chess game.
+    pub const fn new() -> Chess {
+        Chess {
+            board: Board::new(),
+            turn: White,
+            castles: Castles::new(),
+            ep_square: None,
+            halfmoves: 0,
+            fullmoves: match NonZeroU32::new(1) {
+                Some(num) => num,
+                _ => unreachable!(),
+            },
+        }
+    }
 }
 
 impl Default for Chess {
     fn default() -> Chess {
-        Chess {
-            board: Board::default(),
-            turn: White,
-            castles: Castles::default(),
-            ep_square: None,
-            halfmoves: 0,
-            fullmoves: NonZeroU32::new(1).unwrap(),
-        }
+        Chess::new()
     }
 }
 
@@ -754,30 +762,39 @@ impl Position for Chess {
     fn board(&self) -> &Board {
         &self.board
     }
+
     fn promoted(&self) -> Bitboard {
         Bitboard::EMPTY
     }
+
     fn pockets(&self) -> Option<&ByColor<ByRole<u8>>> {
         None
     }
+
     fn turn(&self) -> Color {
         self.turn
     }
+
     fn castles(&self) -> &Castles {
         &self.castles
     }
+
     fn maybe_ep_square(&self) -> Option<Square> {
         self.ep_square.map(EnPassant::square)
     }
+
     fn remaining_checks(&self) -> Option<&ByColor<RemainingChecks>> {
         None
     }
+
     fn halfmoves(&self) -> u32 {
         self.halfmoves
     }
+
     fn fullmoves(&self) -> NonZeroU32 {
         self.fullmoves
     }
+
     fn into_setup(self, mode: EnPassantMode) -> Setup {
         Setup {
             ep_square: self.ep_square(mode),
@@ -1003,16 +1020,25 @@ pub(crate) mod variant {
         fullmoves: NonZeroU32,
     }
 
-    impl Default for Atomic {
-        fn default() -> Atomic {
-            Atomic {
-                board: Board::default(),
+    impl Atomic {
+        pub const fn new() -> Self {
+            Self {
+                board: Board::new(),
                 turn: White,
-                castles: Castles::default(),
+                castles: Castles::new(),
                 ep_square: None,
                 halfmoves: 0,
-                fullmoves: NonZeroU32::new(1).unwrap(),
+                fullmoves: match NonZeroU32::new(1) {
+                    Some(num) => num,
+                    _ => unreachable!(),
+                },
             }
+        }
+    }
+
+    impl Default for Atomic {
+        fn default() -> Atomic {
+            Self::new()
         }
     }
 
@@ -1067,30 +1093,39 @@ pub(crate) mod variant {
         fn board(&self) -> &Board {
             &self.board
         }
+
         fn promoted(&self) -> Bitboard {
             Bitboard::EMPTY
         }
+
         fn pockets(&self) -> Option<&ByColor<ByRole<u8>>> {
             None
         }
+
         fn turn(&self) -> Color {
             self.turn
         }
+
         fn castles(&self) -> &Castles {
             &self.castles
         }
+
         fn maybe_ep_square(&self) -> Option<Square> {
             self.ep_square.map(EnPassant::square)
         }
+
         fn remaining_checks(&self) -> Option<&ByColor<RemainingChecks>> {
             None
         }
+
         fn halfmoves(&self) -> u32 {
             self.halfmoves
         }
+
         fn fullmoves(&self) -> NonZeroU32 {
             self.fullmoves
         }
+
         fn into_setup(self, mode: EnPassantMode) -> Setup {
             Setup {
                 ep_square: self.ep_square(mode),
@@ -1275,16 +1310,25 @@ pub(crate) mod variant {
         fullmoves: NonZeroU32,
     }
 
-    impl Default for Antichess {
-        fn default() -> Antichess {
-            Antichess {
-                board: Board::default(),
+    impl Antichess {
+        pub const fn new() -> Self {
+            Self {
+                board: Board::new(),
                 turn: White,
                 castles: Castles::empty(CastlingMode::Standard),
                 ep_square: None,
                 halfmoves: 0,
-                fullmoves: NonZeroU32::new(1).unwrap(),
+                fullmoves: match NonZeroU32::new(1) {
+                    Some(num) => num,
+                    _ => unreachable!(),
+                },
             }
+        }
+    }
+
+    impl Default for Antichess {
+        fn default() -> Antichess {
+            Self::new()
         }
     }
 
@@ -1330,30 +1374,39 @@ pub(crate) mod variant {
         fn board(&self) -> &Board {
             &self.board
         }
+
         fn promoted(&self) -> Bitboard {
             Bitboard::EMPTY
         }
+
         fn pockets(&self) -> Option<&ByColor<ByRole<u8>>> {
             None
         }
+
         fn turn(&self) -> Color {
             self.turn
         }
+
         fn castles(&self) -> &Castles {
             &self.castles
         }
+
         fn maybe_ep_square(&self) -> Option<Square> {
             self.ep_square.map(EnPassant::square)
         }
+
         fn remaining_checks(&self) -> Option<&ByColor<RemainingChecks>> {
             None
         }
+
         fn halfmoves(&self) -> u32 {
             self.halfmoves
         }
+
         fn fullmoves(&self) -> NonZeroU32 {
             self.fullmoves
         }
+
         fn into_setup(self, mode: EnPassantMode) -> Setup {
             Setup {
                 ep_square: self.ep_square(mode),
@@ -1472,6 +1525,14 @@ pub(crate) mod variant {
         chess: Chess,
     }
 
+    impl KingOfTheHill {
+        pub const fn new() -> KingOfTheHill {
+            Self {
+                chess: Chess::new(),
+            }
+        }
+    }
+
     impl FromSetup for KingOfTheHill {
         fn from_setup(
             setup: Setup,
@@ -1490,30 +1551,39 @@ pub(crate) mod variant {
         fn board(&self) -> &Board {
             self.chess.board()
         }
+
         fn promoted(&self) -> Bitboard {
             Bitboard::EMPTY
         }
+
         fn castles(&self) -> &Castles {
             self.chess.castles()
         }
+
         fn pockets(&self) -> Option<&ByColor<ByRole<u8>>> {
             None
         }
+
         fn turn(&self) -> Color {
             self.chess.turn()
         }
+
         fn maybe_ep_square(&self) -> Option<Square> {
             self.chess.maybe_ep_square()
         }
+
         fn remaining_checks(&self) -> Option<&ByColor<RemainingChecks>> {
             None
         }
+
         fn halfmoves(&self) -> u32 {
             self.chess.halfmoves()
         }
+
         fn fullmoves(&self) -> NonZeroU32 {
             self.chess.fullmoves()
         }
+
         fn into_setup(self, mode: EnPassantMode) -> Setup {
             self.chess.into_setup(mode)
         }
@@ -1580,6 +1650,18 @@ pub(crate) mod variant {
         remaining_checks: ByColor<RemainingChecks>,
     }
 
+    impl ThreeCheck {
+        pub const fn new() -> ThreeCheck {
+            Self {
+                chess: Chess::new(),
+                remaining_checks: ByColor {
+                    black: RemainingChecks::new(3),
+                    white: RemainingChecks::new(3),
+                },
+            }
+        }
+    }
+
     impl FromSetup for ThreeCheck {
         fn from_setup(
             setup: Setup,
@@ -1607,30 +1689,39 @@ pub(crate) mod variant {
         fn board(&self) -> &Board {
             self.chess.board()
         }
+
         fn promoted(&self) -> Bitboard {
             Bitboard::EMPTY
         }
+
         fn pockets(&self) -> Option<&ByColor<ByRole<u8>>> {
             None
         }
+
         fn turn(&self) -> Color {
             self.chess.turn()
         }
+
         fn castles(&self) -> &Castles {
             self.chess.castles()
         }
+
         fn maybe_ep_square(&self) -> Option<Square> {
             self.chess.maybe_ep_square()
         }
+
         fn remaining_checks(&self) -> Option<&ByColor<RemainingChecks>> {
             Some(&self.remaining_checks)
         }
+
         fn halfmoves(&self) -> u32 {
             self.chess.halfmoves()
         }
+
         fn fullmoves(&self) -> NonZeroU32 {
             self.chess.fullmoves
         }
+
         fn into_setup(self, mode: EnPassantMode) -> Setup {
             Setup {
                 remaining_checks: Some(self.remaining_checks),
@@ -1710,6 +1801,31 @@ pub(crate) mod variant {
     }
 
     impl Crazyhouse {
+        pub const fn new() -> Crazyhouse {
+            Self {
+                chess: Chess::new(),
+                promoted: Bitboard::EMPTY,
+                pockets: ByColor {
+                    black: ByRole {
+                        pawn: 0,
+                        knight: 0,
+                        bishop: 0,
+                        rook: 0,
+                        queen: 0,
+                        king: 0,
+                    },
+                    white: ByRole {
+                        pawn: 0,
+                        knight: 0,
+                        bishop: 0,
+                        rook: 0,
+                        queen: 0,
+                        king: 0,
+                    },
+                },
+            }
+        }
+
         fn our_pocket(&self) -> &ByRole<u8> {
             self.pockets.get(self.turn())
         }
@@ -1799,30 +1915,39 @@ pub(crate) mod variant {
         fn board(&self) -> &Board {
             self.chess.board()
         }
+
         fn promoted(&self) -> Bitboard {
             self.promoted
         }
+
         fn pockets(&self) -> Option<&ByColor<ByRole<u8>>> {
             Some(&self.pockets)
         }
+
         fn turn(&self) -> Color {
             self.chess.turn()
         }
+
         fn castles(&self) -> &Castles {
             self.chess.castles()
         }
+
         fn maybe_ep_square(&self) -> Option<Square> {
             self.chess.maybe_ep_square()
         }
+
         fn remaining_checks(&self) -> Option<&ByColor<RemainingChecks>> {
             None
         }
+
         fn halfmoves(&self) -> u32 {
             self.chess.halfmoves()
         }
+
         fn fullmoves(&self) -> NonZeroU32 {
             self.chess.fullmoves()
         }
+
         fn into_setup(self, mode: EnPassantMode) -> Setup {
             Setup {
                 promoted: self.promoted,
@@ -1960,15 +2085,24 @@ pub(crate) mod variant {
         fullmoves: NonZeroU32,
     }
 
-    impl Default for RacingKings {
-        fn default() -> RacingKings {
+    impl RacingKings {
+        pub const fn new() -> RacingKings {
             RacingKings {
                 board: Board::racing_kings(),
                 turn: White,
                 castles: Castles::empty(CastlingMode::Standard),
                 halfmoves: 0,
-                fullmoves: NonZeroU32::new(1).unwrap(),
+                fullmoves: match NonZeroU32::new(1) {
+                    Some(num) => num,
+                    _ => unreachable!(),
+                },
             }
+        }
+    }
+
+    impl Default for RacingKings {
+        fn default() -> RacingKings {
+            RacingKings::new()
         }
     }
 
@@ -1986,6 +2120,7 @@ pub(crate) mod variant {
             if setup.board.pawns().any() {
                 errors |= PositionErrorKinds::VARIANT;
             }
+
             for color in Color::ALL {
                 let us = setup.board.by_color(color);
                 if (setup.board.knights() & us).count() > 2
@@ -1996,6 +2131,7 @@ pub(crate) mod variant {
                     errors |= PositionErrorKinds::IMPOSSIBLE_MATERIAL;
                 }
             }
+
             if setup.ep_square.is_some() {
                 errors |= PositionErrorKinds::INVALID_EP_SQUARE;
             }
@@ -2029,30 +2165,39 @@ pub(crate) mod variant {
         fn board(&self) -> &Board {
             &self.board
         }
+
         fn promoted(&self) -> Bitboard {
             Bitboard::EMPTY
         }
+
         fn pockets(&self) -> Option<&ByColor<ByRole<u8>>> {
             None
         }
+
         fn turn(&self) -> Color {
             self.turn
         }
+
         fn castles(&self) -> &Castles {
             &self.castles
         }
+
         fn maybe_ep_square(&self) -> Option<Square> {
             None
         }
+
         fn remaining_checks(&self) -> Option<&ByColor<RemainingChecks>> {
             None
         }
+
         fn halfmoves(&self) -> u32 {
             self.halfmoves
         }
+
         fn fullmoves(&self) -> NonZeroU32 {
             self.fullmoves
         }
+
         fn into_setup(self, _mode: EnPassantMode) -> Setup {
             Setup {
                 board: self.board,
@@ -2252,30 +2397,39 @@ pub(crate) mod variant {
         fn board(&self) -> &Board {
             &self.board
         }
+
         fn promoted(&self) -> Bitboard {
             Bitboard::EMPTY
         }
+
         fn pockets(&self) -> Option<&ByColor<ByRole<u8>>> {
             None
         }
+
         fn turn(&self) -> Color {
             self.turn
         }
+
         fn castles(&self) -> &Castles {
             &self.castles
         }
+
         fn maybe_ep_square(&self) -> Option<Square> {
             self.ep_square.map(EnPassant::square)
         }
+
         fn remaining_checks(&self) -> Option<&ByColor<RemainingChecks>> {
             None
         }
+
         fn halfmoves(&self) -> u32 {
             self.halfmoves
         }
+
         fn fullmoves(&self) -> NonZeroU32 {
             self.fullmoves
         }
+
         fn into_setup(self, mode: EnPassantMode) -> Setup {
             Setup {
                 ep_square: self.ep_square(mode),
@@ -2781,18 +2935,24 @@ fn validate<P: Position>(pos: &P, ep_square: Option<EnPassant>) -> PositionError
     errors
 }
 
-fn is_standard_material(board: &Board, color: Color) -> bool {
+const fn is_standard_material(board: &Board, color: Color) -> bool {
     let our = board.by_color(color);
-    let promoted_pieces = (board.queens() & our).count().saturating_sub(1)
-        + (board.rooks() & our).count().saturating_sub(2)
-        + (board.knights() & our).count().saturating_sub(2)
-        + (board.bishops() & our & Bitboard::LIGHT_SQUARES)
+    let promoted_pieces = board.queens().intersect(our).count().saturating_sub(1)
+        + board.rooks().intersect(our).count().saturating_sub(2)
+        + board.knights().intersect(our).count().saturating_sub(2)
+        + board
+            .bishops()
+            .intersect(our)
+            .intersect(Bitboard::LIGHT_SQUARES)
             .count()
             .saturating_sub(1)
-        + (board.bishops() & our & Bitboard::DARK_SQUARES)
+        + board
+            .bishops()
+            .intersect(our)
+            .intersect(Bitboard::DARK_SQUARES)
             .count()
             .saturating_sub(1);
-    (board.pawns() & our).count() + promoted_pieces <= 8
+    board.pawns().intersect(our).count() + promoted_pieces <= 8
 }
 
 fn gen_non_king<P: Position>(pos: &P, target: Bitboard, moves: &mut MoveList) {

--- a/src/role.rs
+++ b/src/role.rs
@@ -53,7 +53,7 @@ impl Role {
     ///
     /// assert_eq!(Role::from_char('X'), None);
     /// ```
-    pub fn from_char(ch: char) -> Option<Role> {
+    pub const fn from_char(ch: char) -> Option<Role> {
         match ch {
             'P' | 'p' => Some(Role::Pawn),
             'N' | 'n' => Some(Role::Knight),
@@ -75,7 +75,7 @@ impl Role {
     /// assert_eq!(Role::King.of(Color::Black), Color::Black.king());
     /// ```
     #[inline]
-    pub fn of(self, color: Color) -> Piece {
+    pub const fn of(self, color: Color) -> Piece {
         Piece { color, role: self }
     }
 
@@ -88,7 +88,7 @@ impl Role {
     ///
     /// assert_eq!(Role::Rook.char(), 'r');
     /// ```
-    pub fn char(self) -> char {
+    pub const fn char(self) -> char {
         match self {
             Role::Pawn => 'p',
             Role::Knight => 'n',
@@ -108,7 +108,7 @@ impl Role {
     ///
     /// assert_eq!(Role::Rook.upper_char(), 'R');
     /// ```
-    pub fn upper_char(self) -> char {
+    pub const fn upper_char(self) -> char {
         match self {
             Role::Pawn => 'P',
             Role::Knight => 'N',
@@ -213,7 +213,7 @@ impl<T> ByRole<T> {
     }
 
     #[inline]
-    pub fn get(&self, role: Role) -> &T {
+    pub const fn get(&self, role: Role) -> &T {
         // Safety: Trivial offset into #[repr(C)] struct.
         unsafe {
             &*(self as *const ByRole<T>)
@@ -283,7 +283,7 @@ impl<T> ByRole<T> {
     }
 
     #[inline]
-    pub fn as_ref(&self) -> ByRole<&T> {
+    pub const fn as_ref(&self) -> ByRole<&T> {
         ByRole {
             pawn: &self.pawn,
             knight: &self.knight,

--- a/src/role.rs
+++ b/src/role.rs
@@ -53,14 +53,14 @@ impl Role {
     ///
     /// assert_eq!(Role::from_char('X'), None);
     /// ```
-    pub const fn from_char(ch: char) -> Option<Role> {
+    pub const fn from_char(ch: char) -> Option<Self> {
         match ch {
-            'P' | 'p' => Some(Role::Pawn),
-            'N' | 'n' => Some(Role::Knight),
-            'B' | 'b' => Some(Role::Bishop),
-            'R' | 'r' => Some(Role::Rook),
-            'Q' | 'q' => Some(Role::Queen),
-            'K' | 'k' => Some(Role::King),
+            'P' | 'p' => Some(Self::Pawn),
+            'N' | 'n' => Some(Self::Knight),
+            'B' | 'b' => Some(Self::Bishop),
+            'R' | 'r' => Some(Self::Rook),
+            'Q' | 'q' => Some(Self::Queen),
+            'K' | 'k' => Some(Self::King),
             _ => None,
         }
     }
@@ -90,12 +90,12 @@ impl Role {
     /// ```
     pub const fn char(self) -> char {
         match self {
-            Role::Pawn => 'p',
-            Role::Knight => 'n',
-            Role::Bishop => 'b',
-            Role::Rook => 'r',
-            Role::Queen => 'q',
-            Role::King => 'k',
+            Self::Pawn => 'p',
+            Self::Knight => 'n',
+            Self::Bishop => 'b',
+            Self::Rook => 'r',
+            Self::Queen => 'q',
+            Self::King => 'k',
         }
     }
 
@@ -110,23 +110,23 @@ impl Role {
     /// ```
     pub const fn upper_char(self) -> char {
         match self {
-            Role::Pawn => 'P',
-            Role::Knight => 'N',
-            Role::Bishop => 'B',
-            Role::Rook => 'R',
-            Role::Queen => 'Q',
-            Role::King => 'K',
+            Self::Pawn => 'P',
+            Self::Knight => 'N',
+            Self::Bishop => 'B',
+            Self::Rook => 'R',
+            Self::Queen => 'Q',
+            Self::King => 'K',
         }
     }
 
     /// `Pawn`, `Knight`, `Bishop`, `Rook`, `Queen`, and `King`, in this order.
-    pub const ALL: [Role; 6] = [
-        Role::Pawn,
-        Role::Knight,
-        Role::Bishop,
-        Role::Rook,
-        Role::Queen,
-        Role::King,
+    pub const ALL: [Self; 6] = [
+        Self::Pawn,
+        Self::Knight,
+        Self::Bishop,
+        Self::Rook,
+        Self::Queen,
+        Self::King,
     ];
 }
 
@@ -134,8 +134,8 @@ macro_rules! int_from_role_impl {
     ($($t:ty)+) => {
         $(impl From<Role> for $t {
             #[inline]
-            fn from(role: Role) -> $t {
-                role as $t
+            fn from(role: Role) -> Self {
+                role as Self
             }
         })+
     }
@@ -147,8 +147,8 @@ macro_rules! nonzero_int_from_role_impl {
     ($($t:ty)+) => {
         $(impl From<Role> for $t {
             #[inline]
-            fn from(role: Role) -> $t {
-                <$t>::new(role.into()).expect("nonzero role discriminant")
+            fn from(role: Role) -> Self {
+                Self::new(role.into()).expect("nonzero role discriminant")
             }
         })+
     }
@@ -168,14 +168,14 @@ macro_rules! try_role_from_int_impl {
             type Error = num::TryFromIntError;
 
             #[inline]
-            fn try_from(value: $t) -> Result<Role, Self::Error> {
+            fn try_from(value: $t) -> Result<Self, Self::Error> {
                 Ok(match value {
-                    1 => Role::Pawn,
-                    2 => Role::Knight,
-                    3 => Role::Bishop,
-                    4 => Role::Rook,
-                    5 => Role::Queen,
-                    6 => Role::King,
+                    1 => Self::Pawn,
+                    2 => Self::Knight,
+                    3 => Self::Bishop,
+                    4 => Self::Rook,
+                    5 => Self::Queen,
+                    6 => Self::King,
                     _ => return Err(overflow_error()),
                 })
             }
@@ -198,11 +198,11 @@ pub struct ByRole<T> {
 }
 
 impl<T> ByRole<T> {
-    pub fn new_with<F>(mut init: F) -> ByRole<T>
+    pub fn new_with<F>(mut init: F) -> Self
     where
         F: FnMut(Role) -> T,
     {
-        ByRole {
+        Self {
             pawn: init(Role::Pawn),
             knight: init(Role::Knight),
             bishop: init(Role::Bishop),
@@ -215,21 +215,13 @@ impl<T> ByRole<T> {
     #[inline]
     pub const fn get(&self, role: Role) -> &T {
         // Safety: Trivial offset into #[repr(C)] struct.
-        unsafe {
-            &*(self as *const ByRole<T>)
-                .cast::<T>()
-                .offset(role as isize - 1)
-        }
+        unsafe { &*(self as *const Self).cast::<T>().offset(role as isize - 1) }
     }
 
     #[inline]
     pub fn get_mut(&mut self, role: Role) -> &mut T {
         // Safety: Trivial offset into #[repr(C)] struct.
-        unsafe {
-            &mut *(self as *mut ByRole<T>)
-                .cast::<T>()
-                .offset(role as isize - 1)
-        }
+        unsafe { &mut *(self as *mut Self).cast::<T>().offset(role as isize - 1) }
     }
 
     #[inline]

--- a/src/san.rs
+++ b/src/san.rs
@@ -97,8 +97,8 @@ pub enum SanError {
 impl fmt::Display for SanError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match *self {
-            SanError::IllegalSan => "illegal san",
-            SanError::AmbiguousSan => "ambiguous san",
+            Self::IllegalSan => "illegal san",
+            Self::AmbiguousSan => "ambiguous san",
         })
     }
 }
@@ -131,24 +131,24 @@ impl San {
     /// # Errors
     ///
     /// Returns [`ParseSanError`] if `san` is not syntactically valid.
-    pub fn from_ascii(mut san: &[u8]) -> Result<San, ParseSanError> {
+    pub fn from_ascii(mut san: &[u8]) -> Result<Self, ParseSanError> {
         if san.ends_with(b"#") || san.ends_with(b"+") {
             san = &san[0..(san.len() - 1)];
         }
 
         if san == b"--" {
-            Ok(San::Null)
+            Ok(Self::Null)
         } else if san == b"O-O" {
-            Ok(San::Castle(CastlingSide::KingSide))
+            Ok(Self::Castle(CastlingSide::KingSide))
         } else if san == b"O-O-O" {
-            Ok(San::Castle(CastlingSide::QueenSide))
+            Ok(Self::Castle(CastlingSide::QueenSide))
         } else if san.len() == 3 && san[0] == b'@' {
-            Ok(San::Put {
+            Ok(Self::Put {
                 role: Role::Pawn,
                 to: Square::from_ascii(&san[1..]).map_err(|_| ParseSanError)?,
             })
         } else if san.len() == 4 && san[1] == b'@' {
-            Ok(San::Put {
+            Ok(Self::Put {
                 role: Role::from_char(char::from(san[0])).ok_or(ParseSanError)?,
                 to: Square::from_ascii(&san[2..]).map_err(|_| ParseSanError)?,
             })
@@ -221,7 +221,7 @@ impl San {
                 None => None,
             };
 
-            Ok(San::Normal {
+            Ok(Self::Normal {
                 role,
                 file,
                 rank,
@@ -233,13 +233,13 @@ impl San {
     }
 
     /// Converts a move to Standard Algebraic Notation.
-    pub fn from_move<P: Position>(pos: &P, m: &Move) -> San {
+    pub fn from_move<P: Position>(pos: &P, m: &Move) -> Self {
         let legals = match *m {
             Move::Normal { role, to, .. } if role != Role::Pawn => pos.san_candidates(role, to),
             _ => MoveList::new(),
         };
 
-        San::disambiguate(m, &legals)
+        Self::disambiguate(m, &legals)
     }
 
     /// Tries to convert the `San` to a legal move in the context of a
@@ -250,7 +250,7 @@ impl San {
     /// Returns [`SanError`] if there is no unique matching legal move.
     pub fn to_move<P: Position>(&self, pos: &P) -> Result<Move, SanError> {
         match *self {
-            San::Normal {
+            Self::Normal {
                 role,
                 file,
                 rank,
@@ -289,21 +289,21 @@ impl San {
                         }
                     })
             }
-            San::Castle(side) => pos
+            Self::Castle(side) => pos
                 .castling_moves(side)
                 .first()
                 .cloned()
                 .ok_or(SanError::IllegalSan),
-            San::Put { role, to } => {
+            Self::Put { role, to } => {
                 let mut legals = pos.san_candidates(role, to);
                 legals.retain(|m| matches!(*m, Move::Put { .. }));
                 legals.first().cloned().ok_or(SanError::IllegalSan)
             }
-            San::Null => Err(SanError::IllegalSan),
+            Self::Null => Err(SanError::IllegalSan),
         }
     }
 
-    pub fn disambiguate(m: &Move, moves: &MoveList) -> San {
+    pub fn disambiguate(m: &Move, moves: &MoveList) -> Self {
         match *m {
             Move::Normal {
                 role: Role::Pawn,
@@ -311,7 +311,7 @@ impl San {
                 capture,
                 to,
                 promotion,
-            } => San::Normal {
+            } => Self::Normal {
                 role: Role::Pawn,
                 file: if capture.is_some() {
                     Some(from.file())
@@ -359,7 +359,7 @@ impl San {
                         _ => (rank, file),
                     });
 
-                San::Normal {
+                Self::Normal {
                     role,
                     file: if file { Some(from.file()) } else { None },
                     rank: if rank { Some(from.rank()) } else { None },
@@ -368,7 +368,7 @@ impl San {
                     promotion,
                 }
             }
-            Move::EnPassant { from, to, .. } => San::Normal {
+            Move::EnPassant { from, to, .. } => Self::Normal {
                 role: Role::Pawn,
                 file: Some(from.file()),
                 rank: None,
@@ -377,10 +377,10 @@ impl San {
                 promotion: None,
             },
             Move::Castle { rook, king } if rook.file() < king.file() => {
-                San::Castle(CastlingSide::QueenSide)
+                Self::Castle(CastlingSide::QueenSide)
             }
-            Move::Castle { .. } => San::Castle(CastlingSide::KingSide),
-            Move::Put { role, to } => San::Put { role, to },
+            Move::Castle { .. } => Self::Castle(CastlingSide::KingSide),
+            Move::Put { role, to } => Self::Put { role, to },
         }
     }
 
@@ -437,7 +437,7 @@ impl San {
     /// ```
     pub fn matches(&self, m: &Move) -> bool {
         match *self {
-            San::Normal {
+            Self::Normal {
                 role,
                 file,
                 rank,
@@ -469,12 +469,12 @@ impl San {
                 }
                 _ => false,
             },
-            San::Castle(side) => m.castling_side().map_or(false, |s| side == s),
-            San::Put { role, to } => match *m {
+            Self::Castle(side) => m.castling_side().map_or(false, |s| side == s),
+            Self::Put { role, to } => match *m {
                 Move::Put { role: r, to: t } => r == role && to == t,
                 _ => false,
             },
-            San::Null => false,
+            Self::Null => false,
         }
     }
 }
@@ -482,15 +482,15 @@ impl San {
 impl FromStr for San {
     type Err = ParseSanError;
 
-    fn from_str(san: &str) -> Result<San, ParseSanError> {
-        San::from_ascii(san.as_bytes())
+    fn from_str(san: &str) -> Result<Self, ParseSanError> {
+        Self::from_ascii(san.as_bytes())
     }
 }
 
 impl fmt::Display for San {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            San::Normal {
+            Self::Normal {
                 role,
                 file,
                 rank,
@@ -516,14 +516,14 @@ impl fmt::Display for San {
                 }
                 Ok(())
             }
-            San::Castle(CastlingSide::KingSide) => write!(f, "O-O"),
-            San::Castle(CastlingSide::QueenSide) => write!(f, "O-O-O"),
-            San::Put {
+            Self::Castle(CastlingSide::KingSide) => write!(f, "O-O"),
+            Self::Castle(CastlingSide::QueenSide) => write!(f, "O-O-O"),
+            Self::Put {
                 role: Role::Pawn,
                 to,
             } => write!(f, "@{}", to),
-            San::Put { role, to } => write!(f, "{}@{}", role.upper_char(), to),
-            San::Null => write!(f, "--"),
+            Self::Put { role, to } => write!(f, "{}@{}", role.upper_char(), to),
+            Self::Null => write!(f, "--"),
         }
     }
 }
@@ -538,24 +538,24 @@ pub enum Suffix {
 impl Suffix {
     pub const fn char(self) -> char {
         match self {
-            Suffix::Check => '+',
-            Suffix::Checkmate => '#',
+            Self::Check => '+',
+            Self::Checkmate => '#',
         }
     }
 
-    pub const fn from_char(ch: char) -> Option<Suffix> {
+    pub const fn from_char(ch: char) -> Option<Self> {
         match ch {
-            '+' => Some(Suffix::Check),
-            '#' => Some(Suffix::Checkmate),
+            '+' => Some(Self::Check),
+            '#' => Some(Self::Checkmate),
             _ => None,
         }
     }
 
-    pub fn from_position<P: Position>(pos: &P) -> Option<Suffix> {
+    pub fn from_position<P: Position>(pos: &P) -> Option<Self> {
         if matches!(pos.outcome(), Some(Outcome::Decisive { .. })) {
-            Some(Suffix::Checkmate)
+            Some(Self::Checkmate)
         } else if pos.checkers().any() {
-            Some(Suffix::Check)
+            Some(Self::Check)
         } else {
             None
         }
@@ -581,8 +581,8 @@ impl SanPlus {
     /// # Errors
     ///
     /// Returns [`ParseSanError`] if `san` is not syntactically valid.
-    pub fn from_ascii(san: &[u8]) -> Result<SanPlus, ParseSanError> {
-        San::from_ascii(san).map(|result| SanPlus {
+    pub fn from_ascii(san: &[u8]) -> Result<Self, ParseSanError> {
+        San::from_ascii(san).map(|result| Self {
             san: result,
             suffix: san
                 .last()
@@ -600,16 +600,16 @@ impl SanPlus {
     ///
     /// Illegal moves can corrupt the state of the position and may
     /// (or may not) panic or cause panics on future calls.
-    pub fn from_move_and_play_unchecked<P: Position>(pos: &mut P, m: &Move) -> SanPlus {
+    pub fn from_move_and_play_unchecked<P: Position>(pos: &mut P, m: &Move) -> Self {
         let san = San::from_move(pos, m);
         pos.play_unchecked(m);
-        SanPlus {
+        Self {
             san,
             suffix: Suffix::from_position(pos),
         }
     }
 
-    pub fn from_move<P: Position>(mut pos: P, m: &Move) -> SanPlus {
+    pub fn from_move<P: Position>(mut pos: P, m: &Move) -> Self {
         let moves = match *m {
             Move::Normal { role, to, .. } | Move::Put { role, to } => pos.san_candidates(role, to),
             Move::EnPassant { to, .. } => pos.san_candidates(Role::Pawn, to),
@@ -618,7 +618,7 @@ impl SanPlus {
             }
             Move::Castle { .. } => pos.castling_moves(CastlingSide::QueenSide),
         };
-        SanPlus {
+        Self {
             san: San::disambiguate(m, &moves),
             suffix: if moves.contains(m) {
                 pos.play_unchecked(m);
@@ -633,8 +633,8 @@ impl SanPlus {
 impl FromStr for SanPlus {
     type Err = ParseSanError;
 
-    fn from_str(san: &str) -> Result<SanPlus, ParseSanError> {
-        SanPlus::from_ascii(san.as_bytes())
+    fn from_str(san: &str) -> Result<Self, ParseSanError> {
+        Self::from_ascii(san.as_bytes())
     }
 }
 

--- a/src/san.rs
+++ b/src/san.rs
@@ -536,14 +536,14 @@ pub enum Suffix {
 }
 
 impl Suffix {
-    pub fn char(self) -> char {
+    pub const fn char(self) -> char {
         match self {
             Suffix::Check => '+',
             Suffix::Checkmate => '#',
         }
     }
 
-    pub fn from_char(ch: char) -> Option<Suffix> {
+    pub const fn from_char(ch: char) -> Option<Suffix> {
         match ch {
             '+' => Some(Suffix::Check),
             '#' => Some(Suffix::Checkmate),

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -95,8 +95,8 @@ pub struct Setup {
 
 impl Setup {
     /// Plain, empty board. No pieces. White to play.
-    pub const fn empty() -> Setup {
-        Setup {
+    pub const fn empty() -> Self {
+        Self {
             board: Board::empty(),
             pockets: None,
             promoted: Bitboard::EMPTY,
@@ -113,11 +113,11 @@ impl Setup {
     }
 
     /// Default board setup.
-    pub const fn initial() -> Setup {
-        Setup {
+    pub const fn initial() -> Self {
+        Self {
             board: Board::new(),
             castling_rights: Bitboard::CORNERS,
-            ..Setup::empty()
+            ..Self::empty()
         }
     }
 
@@ -132,8 +132,8 @@ impl Setup {
 }
 
 impl Default for Setup {
-    fn default() -> Setup {
-        Setup::initial()
+    fn default() -> Self {
+        Self::initial()
     }
 }
 
@@ -147,8 +147,8 @@ pub struct Castles {
 }
 
 impl Castles {
-    pub const fn new() -> Castles {
-        Castles {
+    pub const fn new() -> Self {
+        Self {
             mode: CastlingMode::Standard,
             mask: Bitboard::CORNERS,
             rook: ByColor {
@@ -171,22 +171,22 @@ impl Castles {
 
 impl Default for Castles {
     fn default() -> Self {
-        Castles::new()
+        Self::new()
     }
 }
 
 impl CastlingMode {
-    pub fn detect(setup: &Setup) -> CastlingMode {
+    pub fn detect(setup: &Setup) -> Self {
         use core::convert::identity;
-        let standard = Castles::from_setup(setup, CastlingMode::Standard).unwrap_or_else(identity);
-        let chess960 = Castles::from_setup(setup, CastlingMode::Chess960).unwrap_or_else(identity);
-        CastlingMode::from_standard(standard.mask == chess960.mask)
+        let standard = Castles::from_setup(setup, Self::Standard).unwrap_or_else(identity);
+        let chess960 = Castles::from_setup(setup, Self::Chess960).unwrap_or_else(identity);
+        Self::from_standard(standard.mask == chess960.mask)
     }
 }
 
 impl Castles {
-    pub const fn empty(mode: CastlingMode) -> Castles {
-        Castles {
+    pub const fn empty(mode: CastlingMode) -> Self {
+        Self {
             mode,
             mask: Bitboard(0),
             rook: ByColor {
@@ -200,8 +200,8 @@ impl Castles {
         }
     }
 
-    pub fn from_setup(setup: &Setup, mode: CastlingMode) -> Result<Castles, Castles> {
-        let mut castles = Castles::empty(mode);
+    pub fn from_setup(setup: &Setup, mode: CastlingMode) -> Result<Self, Self> {
+        let mut castles = Self::empty(mode);
         let rooks = setup.castling_rights & setup.board.rooks();
 
         for color in Color::ALL {
@@ -273,7 +273,9 @@ impl Castles {
     }
 
     pub const fn has_color(&self, color: Color) -> bool {
-        self.mask.intersect(Bitboard::from_rank(color.backrank())).any()
+        self.mask
+            .intersect(Bitboard::from_rank(color.backrank()))
+            .any()
     }
 
     pub fn discard_rook(&mut self, square: Square) {
@@ -352,13 +354,13 @@ impl Castles {
 pub(crate) struct EnPassant(pub Square);
 
 impl From<EnPassant> for Square {
-    fn from(ep: EnPassant) -> Square {
+    fn from(ep: EnPassant) -> Self {
         ep.square()
     }
 }
 
 impl EnPassant {
-    pub fn from_setup(setup: &Setup) -> Result<Option<EnPassant>, ()> {
+    pub fn from_setup(setup: &Setup) -> Result<Option<Self>, ()> {
         let ep_square = match setup.ep_square {
             Some(ep_square) => ep_square,
             None => return Ok(None),
@@ -368,7 +370,7 @@ impl EnPassant {
             return Err(());
         }
 
-        let maybe = EnPassant(ep_square);
+        let maybe = Self(ep_square);
 
         // The last move must have been a double pawn push. Check for the
         // presence of that pawn.
@@ -384,7 +386,7 @@ impl EnPassant {
             return Err(());
         }
 
-        Ok(Some(EnPassant(ep_square)))
+        Ok(Some(Self(ep_square)))
     }
 
     #[inline]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -94,7 +94,8 @@ pub struct Setup {
 }
 
 impl Setup {
-    pub fn empty() -> Setup {
+    /// Plain, empty board. No pieces. White to play.
+    pub const fn empty() -> Setup {
         Setup {
             board: Board::empty(),
             pockets: None,
@@ -104,7 +105,19 @@ impl Setup {
             ep_square: None,
             remaining_checks: None,
             halfmoves: 0,
-            fullmoves: NonZeroU32::new(1).unwrap(),
+            fullmoves: match NonZeroU32::new(1) {
+                Some(num) => num,
+                _ => unreachable!(),
+            },
+        }
+    }
+
+    /// Default board setup.
+    pub const fn initial() -> Setup {
+        Setup {
+            board: Board::new(),
+            castling_rights: Bitboard::CORNERS,
+            ..Setup::empty()
         }
     }
 
@@ -120,11 +133,7 @@ impl Setup {
 
 impl Default for Setup {
     fn default() -> Setup {
-        Setup {
-            board: Board::default(),
-            castling_rights: Bitboard::CORNERS,
-            ..Setup::empty()
-        }
+        Setup::initial()
     }
 }
 
@@ -137,8 +146,8 @@ pub struct Castles {
     mode: CastlingMode,
 }
 
-impl Default for Castles {
-    fn default() -> Castles {
+impl Castles {
+    pub const fn new() -> Castles {
         Castles {
             mode: CastlingMode::Standard,
             mask: Bitboard::CORNERS,
@@ -160,27 +169,39 @@ impl Default for Castles {
     }
 }
 
+impl Default for Castles {
+    fn default() -> Self {
+        Castles::new()
+    }
+}
+
 impl CastlingMode {
     pub fn detect(setup: &Setup) -> CastlingMode {
-        let standard = Castles::from_setup(setup, CastlingMode::Standard).unwrap_or_else(|c| c);
-        let chess960 = Castles::from_setup(setup, CastlingMode::Chess960).unwrap_or_else(|c| c);
+        use core::convert::identity;
+        let standard = Castles::from_setup(setup, CastlingMode::Standard).unwrap_or_else(identity);
+        let chess960 = Castles::from_setup(setup, CastlingMode::Chess960).unwrap_or_else(identity);
         CastlingMode::from_standard(standard.mask == chess960.mask)
     }
 }
 
 impl Castles {
-    pub fn empty(mode: CastlingMode) -> Castles {
+    pub const fn empty(mode: CastlingMode) -> Castles {
         Castles {
             mode,
             mask: Bitboard(0),
-            rook: ByColor::default(),
-            path: ByColor::default(),
+            rook: ByColor {
+                black: [None; 2],
+                white: [None; 2],
+            },
+            path: ByColor {
+                black: [Bitboard::EMPTY; 2],
+                white: [Bitboard::EMPTY; 2],
+            },
         }
     }
 
     pub fn from_setup(setup: &Setup, mode: CastlingMode) -> Result<Castles, Castles> {
         let mut castles = Castles::empty(mode);
-
         let rooks = setup.castling_rights & setup.board.rooks();
 
         for color in Color::ALL {
@@ -234,11 +255,11 @@ impl Castles {
         }
     }
 
-    pub fn any(&self) -> bool {
+    pub const fn any(&self) -> bool {
         self.mask.any()
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.mask.is_empty()
     }
 
@@ -247,12 +268,12 @@ impl Castles {
     }
 
     #[deprecated = "renamed to Castles::has_color()"]
-    pub fn has_side(&self, color: Color) -> bool {
+    pub const fn has_side(&self, color: Color) -> bool {
         self.has_color(color)
     }
 
-    pub fn has_color(&self, color: Color) -> bool {
-        (self.mask & color.backrank()).any()
+    pub const fn has_color(&self, color: Color) -> bool {
+        self.mask.intersect(Bitboard::from_rank(color.backrank())).any()
     }
 
     pub fn discard_rook(&mut self, square: Square) {
@@ -284,7 +305,7 @@ impl Castles {
     }
 
     #[inline]
-    pub fn rook(&self, color: Color, side: CastlingSide) -> Option<Square> {
+    pub const fn rook(&self, color: Color, side: CastlingSide) -> Option<Square> {
         self.rook.get(color)[side as usize]
     }
 
@@ -311,17 +332,17 @@ impl Castles {
     /// assert_eq!(path, Bitboard::from(Square::B1) | Bitboard::from(Square::C1) | Bitboard::from(Square::D1));
     /// ```
     #[inline]
-    pub fn path(&self, color: Color, side: CastlingSide) -> Bitboard {
+    pub const fn path(&self, color: Color, side: CastlingSide) -> Bitboard {
         self.path.get(color)[side as usize]
     }
 
     /// Castling rigths in terms of corresponding rook positions.
     #[inline]
-    pub fn castling_rights(&self) -> Bitboard {
+    pub const fn castling_rights(&self) -> Bitboard {
         self.mask
     }
 
-    pub fn mode(&self) -> CastlingMode {
+    pub const fn mode(&self) -> CastlingMode {
         self.mode
     }
 }
@@ -367,7 +388,7 @@ impl EnPassant {
     }
 
     #[inline]
-    pub fn square(self) -> Square {
+    pub const fn square(self) -> Square {
         self.0
     }
 

--- a/src/square.rs
+++ b/src/square.rs
@@ -121,7 +121,7 @@ impl File {
     ///
     /// Panics if the index is not in the range `0..=7`.
     #[inline]
-    pub fn new(index: u32) -> File {
+    pub const fn new(index: u32) -> File {
         assert!(index < 8);
         unsafe { File::new_unchecked(index) }
     }
@@ -133,7 +133,7 @@ impl File {
     /// It is the callers responsibility to ensure the index is in the range
     /// `0..=7`.
     #[inline]
-    pub unsafe fn new_unchecked(index: u32) -> File {
+    pub const unsafe fn new_unchecked(index: u32) -> File {
         debug_assert!(index < 8);
         unsafe { mem::transmute(index as u8) }
     }

--- a/src/square.rs
+++ b/src/square.rs
@@ -31,8 +31,8 @@ macro_rules! from_repr_u8_impl {
         $(impl From<$from> for $t {
             #[inline]
             #[allow(clippy::cast_lossless)]
-            fn from(value: $from) -> $t {
-                value as u8 as $t
+            fn from(value: $from) -> Self {
+                value as u8 as Self
             }
         })+
     }
@@ -46,9 +46,9 @@ macro_rules! try_from_int_impl {
             #[inline]
             #[allow(unused_comparisons)]
             #[allow(clippy::cast_lossless)]
-            fn try_from(value: $t) -> Result<$type, Self::Error> {
+            fn try_from(value: $t) -> Result<Self, Self::Error> {
                 if ($lower..$upper).contains(&value) {
-                    Ok(<$type>::new(value as u32))
+                    Ok(Self::new(value as u32))
                 } else {
                     Err(overflow_error())
                 }
@@ -121,9 +121,9 @@ impl File {
     ///
     /// Panics if the index is not in the range `0..=7`.
     #[inline]
-    pub const fn new(index: u32) -> File {
+    pub const fn new(index: u32) -> Self {
         assert!(index < 8);
-        unsafe { File::new_unchecked(index) }
+        unsafe { Self::new_unchecked(index) }
     }
 
     /// Gets a `File` from an integer index.
@@ -133,15 +133,15 @@ impl File {
     /// It is the callers responsibility to ensure the index is in the range
     /// `0..=7`.
     #[inline]
-    pub const unsafe fn new_unchecked(index: u32) -> File {
+    pub const unsafe fn new_unchecked(index: u32) -> Self {
         debug_assert!(index < 8);
         unsafe { mem::transmute(index as u8) }
     }
 
     #[inline]
-    pub fn from_char(ch: char) -> Option<File> {
+    pub fn from_char(ch: char) -> Option<Self> {
         if ('a'..='h').contains(&ch) {
-            Some(File::new(u32::from(ch as u8 - b'a')))
+            Some(Self::new(u32::from(ch as u8 - b'a')))
         } else {
             None
         }
@@ -159,21 +159,21 @@ impl File {
 
     #[must_use]
     #[inline]
-    pub fn offset(self, delta: i32) -> Option<File> {
+    pub fn offset(self, delta: i32) -> Option<Self> {
         i32::from(self)
             .checked_add(delta)
             .and_then(|index| index.try_into().ok())
     }
 
     #[inline]
-    pub fn distance(self, other: File) -> u32 {
+    pub fn distance(self, other: Self) -> u32 {
         u32::from(self).abs_diff(u32::from(other))
     }
 
     #[must_use]
     #[inline]
-    pub fn flip_horizontal(self) -> File {
-        File::new(7 - u32::from(self))
+    pub fn flip_horizontal(self) -> Self {
+        Self::new(7 - u32::from(self))
     }
 
     #[must_use]
@@ -189,15 +189,15 @@ impl File {
     }
 
     /// `A`, ..., `H`.
-    pub const ALL: [File; 8] = [
-        File::A,
-        File::B,
-        File::C,
-        File::D,
-        File::E,
-        File::F,
-        File::G,
-        File::H,
+    pub const ALL: [Self; 8] = [
+        Self::A,
+        Self::B,
+        Self::C,
+        Self::D,
+        Self::E,
+        Self::F,
+        Self::G,
+        Self::H,
     ];
 }
 
@@ -205,7 +205,7 @@ impl Sub for File {
     type Output = i32;
 
     #[inline]
-    fn sub(self, other: File) -> i32 {
+    fn sub(self, other: Self) -> i32 {
         i32::from(self) - i32::from(other)
     }
 }
@@ -242,9 +242,9 @@ impl Rank {
     ///
     /// Panics if the index is not in the range `0..=7`.
     #[inline]
-    pub fn new(index: u32) -> Rank {
+    pub fn new(index: u32) -> Self {
         assert!(index < 8);
-        unsafe { Rank::new_unchecked(index) }
+        unsafe { Self::new_unchecked(index) }
     }
 
     /// Gets a `Rank` from an integer index.
@@ -254,15 +254,15 @@ impl Rank {
     /// It is the callers responsibility to ensure the index is in the range
     /// `0..=7`.
     #[inline]
-    pub unsafe fn new_unchecked(index: u32) -> Rank {
+    pub unsafe fn new_unchecked(index: u32) -> Self {
         debug_assert!(index < 8);
         unsafe { mem::transmute(index as u8) }
     }
 
     #[inline]
-    pub fn from_char(ch: char) -> Option<Rank> {
+    pub fn from_char(ch: char) -> Option<Self> {
         if ('1'..='8').contains(&ch) {
-            Some(Rank::new(u32::from(ch as u8 - b'1')))
+            Some(Self::new(u32::from(ch as u8 - b'1')))
         } else {
             None
         }
@@ -275,21 +275,21 @@ impl Rank {
 
     #[must_use]
     #[inline]
-    pub fn offset(self, delta: i32) -> Option<Rank> {
+    pub fn offset(self, delta: i32) -> Option<Self> {
         i32::from(self)
             .checked_add(delta)
             .and_then(|index| index.try_into().ok())
     }
 
     #[inline]
-    pub fn distance(self, other: Rank) -> u32 {
+    pub fn distance(self, other: Self) -> u32 {
         u32::from(self).abs_diff(u32::from(other))
     }
 
     #[must_use]
     #[inline]
-    pub fn flip_vertical(self) -> Rank {
-        Rank::new(7 - u32::from(self))
+    pub fn flip_vertical(self) -> Self {
+        Self::new(7 - u32::from(self))
     }
 
     #[must_use]
@@ -305,15 +305,15 @@ impl Rank {
     }
 
     /// `First`, ..., `Eighth`.
-    pub const ALL: [Rank; 8] = [
-        Rank::First,
-        Rank::Second,
-        Rank::Third,
-        Rank::Fourth,
-        Rank::Fifth,
-        Rank::Sixth,
-        Rank::Seventh,
-        Rank::Eighth,
+    pub const ALL: [Self; 8] = [
+        Self::First,
+        Self::Second,
+        Self::Third,
+        Self::Fourth,
+        Self::Fifth,
+        Self::Sixth,
+        Self::Seventh,
+        Self::Eighth,
     ];
 }
 
@@ -321,7 +321,7 @@ impl Sub for Rank {
     type Output = i32;
 
     #[inline]
-    fn sub(self, other: Rank) -> i32 {
+    fn sub(self, other: Self) -> i32 {
         i32::from(self) - i32::from(other)
     }
 }
@@ -381,9 +381,9 @@ impl Square {
     /// assert_eq!(Square::new(63), Square::H8);
     /// ```
     #[inline]
-    pub const fn new(index: u32) -> Square {
+    pub const fn new(index: u32) -> Self {
         assert!(index < 64);
-        unsafe { Square::new_unchecked(index) }
+        unsafe { Self::new_unchecked(index) }
     }
 
     /// Gets a `Square` from an integer index.
@@ -392,7 +392,7 @@ impl Square {
     ///
     /// It is the callers responsibility to ensure it is in the range `0..=63`.
     #[inline]
-    pub const unsafe fn new_unchecked(index: u32) -> Square {
+    pub const unsafe fn new_unchecked(index: u32) -> Self {
         debug_assert!(index < 64);
         unsafe { mem::transmute(index as u8) }
     }
@@ -407,10 +407,10 @@ impl Square {
     /// assert_eq!(Square::from_coords(File::A, Rank::First), Square::A1);
     /// ```
     #[inline]
-    pub fn from_coords(file: File, rank: Rank) -> Square {
+    pub fn from_coords(file: File, rank: Rank) -> Self {
         // Safety: Files and ranks are represented with 3 bits each, and all
         // 6 bit values are in the range 0..=63.
-        unsafe { Square::new_unchecked(u32::from(file) | (u32::from(rank) << 3)) }
+        unsafe { Self::new_unchecked(u32::from(file) | (u32::from(rank) << 3)) }
     }
 
     /// Parses a square name.
@@ -429,13 +429,13 @@ impl Square {
     /// # Ok::<_, shakmaty::ParseSquareError>(())
     /// ```
     #[inline]
-    pub fn from_ascii(s: &[u8]) -> Result<Square, ParseSquareError> {
+    pub fn from_ascii(s: &[u8]) -> Result<Self, ParseSquareError> {
         if s.len() == 2 {
             match (
                 File::from_char(char::from(s[0])),
                 Rank::from_char(char::from(s[1])),
             ) {
-                (Some(file), Some(rank)) => Ok(Square::from_coords(file, rank)),
+                (Some(file), Some(rank)) => Ok(Self::from_coords(file, rank)),
                 _ => Err(ParseSquareError),
             }
         } else {
@@ -502,7 +502,7 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn offset(self, delta: i32) -> Option<Square> {
+    pub fn offset(self, delta: i32) -> Option<Self> {
         i32::from(self)
             .checked_add(delta)
             .and_then(|index| index.try_into().ok())
@@ -517,18 +517,18 @@ impl Square {
     /// offset for `self`.
     #[must_use]
     #[inline]
-    pub unsafe fn offset_unchecked(self, delta: i32) -> Square {
+    pub unsafe fn offset_unchecked(self, delta: i32) -> Self {
         debug_assert!(-64 < delta && delta < 64);
-        unsafe { Square::new_unchecked((i32::from(self) + delta) as u32) }
+        unsafe { Self::new_unchecked((i32::from(self) + delta) as u32) }
     }
 
     /// Return the bitwise XOR of the numeric square representations. For some
     /// operands this is a useful geometric transformation.
     #[must_use]
     #[inline]
-    pub fn xor(self, other: Square) -> Square {
+    pub fn xor(self, other: Self) -> Self {
         // Safety: 6 bit value XOR 6 bit value -> 6 bit value.
-        unsafe { Square::new_unchecked(u32::from(self) ^ u32::from(other)) }
+        unsafe { Self::new_unchecked(u32::from(self) ^ u32::from(other)) }
     }
 
     /// Flip the square horizontally.
@@ -542,8 +542,8 @@ impl Square {
     #[must_use]
     #[inline]
     #[allow(clippy::unusual_byte_groupings)]
-    pub fn flip_horizontal(self) -> Square {
-        self.xor(Square::H1)
+    pub fn flip_horizontal(self) -> Self {
+        self.xor(Self::H1)
     }
 
     /// Flip the square vertically.
@@ -557,8 +557,8 @@ impl Square {
     #[must_use]
     #[inline]
     #[allow(clippy::unusual_byte_groupings)]
-    pub fn flip_vertical(self) -> Square {
-        self.xor(Square::A8)
+    pub fn flip_vertical(self) -> Self {
+        self.xor(Self::A8)
     }
 
     /// Flip at the a1-h8 diagonal by swapping file and rank.
@@ -571,11 +571,11 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn flip_diagonal(self) -> Square {
+    pub fn flip_diagonal(self) -> Self {
         // See https://www.chessprogramming.org/Flipping_Mirroring_and_Rotating#Diagonal.
         // Safety: We are selecting 32 - 26 = 6 bits with the shift, and all
         // 6 bits values are in the range 0..=63.
-        unsafe { Square::new_unchecked(u32::from(self).wrapping_mul(0x2080_0000) >> 26) }
+        unsafe { Self::new_unchecked(u32::from(self).wrapping_mul(0x2080_0000) >> 26) }
     }
 
     /// Flip at the h1-a8 diagonal.
@@ -588,7 +588,7 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn flip_anti_diagonal(self) -> Square {
+    pub fn flip_anti_diagonal(self) -> Self {
         self.flip_diagonal().rotate_180()
     }
 
@@ -602,7 +602,7 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn rotate_90(self) -> Square {
+    pub fn rotate_90(self) -> Self {
         self.flip_diagonal().flip_vertical()
     }
 
@@ -617,8 +617,8 @@ impl Square {
     #[must_use]
     #[inline]
     #[allow(clippy::unusual_byte_groupings)]
-    pub fn rotate_180(self) -> Square {
-        self.xor(Square::H8)
+    pub fn rotate_180(self) -> Self {
+        self.xor(Self::H8)
     }
 
     /// Rotate 270 degrees clockwise.
@@ -631,7 +631,7 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn rotate_270(self) -> Square {
+    pub fn rotate_270(self) -> Self {
         self.flip_diagonal().flip_horizontal()
     }
 
@@ -669,7 +669,7 @@ impl Square {
     ///
     /// assert_eq!(Square::A2.distance(Square::B5), 3);
     /// ```
-    pub fn distance(self, other: Square) -> u32 {
+    pub fn distance(self, other: Self) -> u32 {
         max(
             self.file().distance(other.file()),
             self.rank().distance(other.rank()),
@@ -682,7 +682,7 @@ mod all_squares {
     impl Square {
         /// `A1`, `B1`, ..., `G8`, `H8`.
         #[rustfmt::skip]
-        pub const ALL: [Square; 64] = [
+        pub const ALL: [Self; 64] = [
             A1, B1, C1, D1, E1, F1, G1, H1,
             A2, B2, C2, D2, E2, F2, G2, H2,
             A3, B3, C3, D3, E3, F3, G3, H3,
@@ -703,23 +703,23 @@ impl Sub for Square {
     type Output = i32;
 
     #[inline]
-    fn sub(self, other: Square) -> i32 {
+    fn sub(self, other: Self) -> i32 {
         i32::from(self) - i32::from(other)
     }
 }
 
 impl From<(File, Rank)> for Square {
     #[inline]
-    fn from((file, rank): (File, Rank)) -> Square {
-        Square::from_coords(file, rank)
+    fn from((file, rank): (File, Rank)) -> Self {
+        Self::from_coords(file, rank)
     }
 }
 
 impl str::FromStr for Square {
     type Err = ParseSquareError;
 
-    fn from_str(s: &str) -> Result<Square, ParseSquareError> {
-        Square::from_ascii(s.as_bytes())
+    fn from_str(s: &str) -> Result<Self, ParseSquareError> {
+        Self::from_ascii(s.as_bytes())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -71,7 +71,7 @@ pub enum Move {
 
 impl Move {
     /// Gets the role of the moved piece.
-    pub fn role(&self) -> Role {
+    pub const fn role(&self) -> Role {
         match *self {
             Move::Normal { role, .. } | Move::Put { role, .. } => role,
             Move::EnPassant { .. } => Role::Pawn,
@@ -80,7 +80,7 @@ impl Move {
     }
 
     /// Gets the origin square or `None` for drops.
-    pub fn from(&self) -> Option<Square> {
+    pub const fn from(&self) -> Option<Square> {
         match *self {
             Move::Normal { from, .. } | Move::EnPassant { from, .. } => Some(from),
             Move::Castle { king, .. } => Some(king),
@@ -90,7 +90,7 @@ impl Move {
 
     /// Gets the target square. For castling moves this is the corresponding
     /// rook square.
-    pub fn to(&self) -> Square {
+    pub const fn to(&self) -> Square {
         match *self {
             Move::Normal { to, .. } | Move::EnPassant { to, .. } | Move::Put { to, .. } => to,
             Move::Castle { rook, .. } => rook,
@@ -98,7 +98,7 @@ impl Move {
     }
 
     /// Gets the role of the captured piece or `None`.
-    pub fn capture(&self) -> Option<Role> {
+    pub const fn capture(&self) -> Option<Role> {
         match *self {
             Move::Normal { capture, .. } => capture,
             Move::EnPassant { .. } => Some(Role::Pawn),
@@ -107,7 +107,7 @@ impl Move {
     }
 
     /// Checks if the move is a capture.
-    pub fn is_capture(&self) -> bool {
+    pub const fn is_capture(&self) -> bool {
         matches!(
             *self,
             Move::Normal {
@@ -118,12 +118,12 @@ impl Move {
     }
 
     /// Checks if the move is en passant.
-    pub fn is_en_passant(&self) -> bool {
+    pub const fn is_en_passant(&self) -> bool {
         matches!(*self, Move::EnPassant { .. })
     }
 
     /// Checks if the move zeros the half-move clock.
-    pub fn is_zeroing(&self) -> bool {
+    pub const fn is_zeroing(&self) -> bool {
         matches!(
             *self,
             Move::Normal {
@@ -150,12 +150,12 @@ impl Move {
     }
 
     /// Checks if the move is a castling move.
-    pub fn is_castle(&self) -> bool {
+    pub const fn is_castle(&self) -> bool {
         matches!(*self, Move::Castle { .. })
     }
 
     /// Gets the promotion role.
-    pub fn promotion(&self) -> Option<Role> {
+    pub const fn promotion(&self) -> Option<Role> {
         match *self {
             Move::Normal { promotion, .. } => promotion,
             _ => None,
@@ -163,7 +163,7 @@ impl Move {
     }
 
     /// Checks if the move is a promotion.
-    pub fn is_promotion(&self) -> bool {
+    pub const fn is_promotion(&self) -> bool {
         matches!(
             *self,
             Move::Normal {
@@ -224,18 +224,18 @@ pub enum CastlingSide {
 }
 
 impl CastlingSide {
-    pub fn is_queen_side(self) -> bool {
+    pub const fn is_queen_side(self) -> bool {
         match self {
             CastlingSide::KingSide => false,
             CastlingSide::QueenSide => true,
         }
     }
 
-    pub fn is_king_side(self) -> bool {
+    pub const fn is_king_side(self) -> bool {
         !self.is_queen_side()
     }
 
-    pub fn from_queen_side(queen_side: bool) -> CastlingSide {
+    pub const fn from_queen_side(queen_side: bool) -> CastlingSide {
         if queen_side {
             CastlingSide::QueenSide
         } else {
@@ -243,7 +243,7 @@ impl CastlingSide {
         }
     }
 
-    pub fn from_king_side(king_side: bool) -> CastlingSide {
+    pub const fn from_king_side(king_side: bool) -> CastlingSide {
         if king_side {
             CastlingSide::KingSide
         } else {
@@ -251,14 +251,14 @@ impl CastlingSide {
         }
     }
 
-    pub fn king_to_file(self) -> File {
+    pub const fn king_to_file(self) -> File {
         match self {
             CastlingSide::KingSide => File::G,
             CastlingSide::QueenSide => File::C,
         }
     }
 
-    pub fn rook_to_file(self) -> File {
+    pub const fn rook_to_file(self) -> File {
         match self {
             CastlingSide::KingSide => File::F,
             CastlingSide::QueenSide => File::D,
@@ -285,7 +285,7 @@ pub enum CastlingMode {
 }
 
 impl CastlingMode {
-    pub fn from_standard(standard: bool) -> CastlingMode {
+    pub const fn from_standard(standard: bool) -> CastlingMode {
         if standard {
             CastlingMode::Standard
         } else {
@@ -293,7 +293,7 @@ impl CastlingMode {
         }
     }
 
-    pub fn from_chess960(chess960: bool) -> CastlingMode {
+    pub const fn from_chess960(chess960: bool) -> CastlingMode {
         if chess960 {
             CastlingMode::Chess960
         } else {
@@ -301,12 +301,12 @@ impl CastlingMode {
         }
     }
 
-    pub fn is_standard(self) -> bool {
-        self == CastlingMode::Standard
+    pub const fn is_standard(self) -> bool {
+        matches!(self, CastlingMode::Standard)
     }
 
-    pub fn is_chess960(self) -> bool {
-        self == CastlingMode::Chess960
+    pub const fn is_chess960(self) -> bool {
+        matches!(self, CastlingMode::Chess960)
     }
 }
 
@@ -380,17 +380,17 @@ impl RemainingChecks {
     /// # Panics
     ///
     /// Panics if `n > 3`.
-    pub fn new(n: u32) -> RemainingChecks {
+    pub const fn new(n: u32) -> RemainingChecks {
         assert!(n <= 3);
         RemainingChecks(n)
     }
 
-    pub fn is_zero(self) -> bool {
+    pub const fn is_zero(self) -> bool {
         self.0 == 0
     }
 
     #[must_use]
-    pub fn saturating_sub(self, n: u32) -> RemainingChecks {
+    pub const fn saturating_sub(self, n: u32) -> RemainingChecks {
         RemainingChecks(self.0.saturating_sub(n))
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -39,7 +39,7 @@ impl Piece {
         self.color.fold_wb(self.role.upper_char(), self.role.char())
     }
 
-    pub fn from_char(ch: char) -> Option<Piece> {
+    pub fn from_char(ch: char) -> Option<Self> {
         Role::from_char(ch).map(|role| role.of(Color::from_white(32 & ch as u8 == 0)))
     }
 }
@@ -73,18 +73,18 @@ impl Move {
     /// Gets the role of the moved piece.
     pub const fn role(&self) -> Role {
         match *self {
-            Move::Normal { role, .. } | Move::Put { role, .. } => role,
-            Move::EnPassant { .. } => Role::Pawn,
-            Move::Castle { .. } => Role::King,
+            Self::Normal { role, .. } | Self::Put { role, .. } => role,
+            Self::EnPassant { .. } => Role::Pawn,
+            Self::Castle { .. } => Role::King,
         }
     }
 
     /// Gets the origin square or `None` for drops.
     pub const fn from(&self) -> Option<Square> {
         match *self {
-            Move::Normal { from, .. } | Move::EnPassant { from, .. } => Some(from),
-            Move::Castle { king, .. } => Some(king),
-            Move::Put { .. } => None,
+            Self::Normal { from, .. } | Self::EnPassant { from, .. } => Some(from),
+            Self::Castle { king, .. } => Some(king),
+            Self::Put { .. } => None,
         }
     }
 
@@ -92,16 +92,16 @@ impl Move {
     /// rook square.
     pub const fn to(&self) -> Square {
         match *self {
-            Move::Normal { to, .. } | Move::EnPassant { to, .. } | Move::Put { to, .. } => to,
-            Move::Castle { rook, .. } => rook,
+            Self::Normal { to, .. } | Self::EnPassant { to, .. } | Self::Put { to, .. } => to,
+            Self::Castle { rook, .. } => rook,
         }
     }
 
     /// Gets the role of the captured piece or `None`.
     pub const fn capture(&self) -> Option<Role> {
         match *self {
-            Move::Normal { capture, .. } => capture,
-            Move::EnPassant { .. } => Some(Role::Pawn),
+            Self::Normal { capture, .. } => capture,
+            Self::EnPassant { .. } => Some(Role::Pawn),
             _ => None,
         }
     }
@@ -110,30 +110,30 @@ impl Move {
     pub const fn is_capture(&self) -> bool {
         matches!(
             *self,
-            Move::Normal {
+            Self::Normal {
                 capture: Some(_),
                 ..
-            } | Move::EnPassant { .. }
+            } | Self::EnPassant { .. }
         )
     }
 
     /// Checks if the move is en passant.
     pub const fn is_en_passant(&self) -> bool {
-        matches!(*self, Move::EnPassant { .. })
+        matches!(*self, Self::EnPassant { .. })
     }
 
     /// Checks if the move zeros the half-move clock.
     pub const fn is_zeroing(&self) -> bool {
         matches!(
             *self,
-            Move::Normal {
+            Self::Normal {
                 role: Role::Pawn,
                 ..
-            } | Move::Normal {
+            } | Self::Normal {
                 capture: Some(_),
                 ..
-            } | Move::EnPassant { .. }
-                | Move::Put {
+            } | Self::EnPassant { .. }
+                | Self::Put {
                     role: Role::Pawn,
                     ..
                 }
@@ -143,21 +143,21 @@ impl Move {
     /// Gets the castling side.
     pub fn castling_side(&self) -> Option<CastlingSide> {
         match *self {
-            Move::Castle { king, rook } if king < rook => Some(CastlingSide::KingSide),
-            Move::Castle { .. } => Some(CastlingSide::QueenSide),
+            Self::Castle { king, rook } if king < rook => Some(CastlingSide::KingSide),
+            Self::Castle { .. } => Some(CastlingSide::QueenSide),
             _ => None,
         }
     }
 
     /// Checks if the move is a castling move.
     pub const fn is_castle(&self) -> bool {
-        matches!(*self, Move::Castle { .. })
+        matches!(*self, Self::Castle { .. })
     }
 
     /// Gets the promotion role.
     pub const fn promotion(&self) -> Option<Role> {
         match *self {
-            Move::Normal { promotion, .. } => promotion,
+            Self::Normal { promotion, .. } => promotion,
             _ => None,
         }
     }
@@ -166,7 +166,7 @@ impl Move {
     pub const fn is_promotion(&self) -> bool {
         matches!(
             *self,
-            Move::Normal {
+            Self::Normal {
                 promotion: Some(_),
                 ..
             }
@@ -177,7 +177,7 @@ impl Move {
 impl fmt::Display for Move {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Move::Normal {
+            Self::Normal {
                 role,
                 from,
                 capture,
@@ -202,11 +202,11 @@ impl fmt::Display for Move {
 
                 Ok(())
             }
-            Move::EnPassant { from, to, .. } => {
+            Self::EnPassant { from, to, .. } => {
                 write!(f, "{}x{}", from, to)
             }
-            Move::Castle { king, rook } => f.write_str(if king < rook { "O-O" } else { "O-O-O" }),
-            Move::Put { role, to } => {
+            Self::Castle { king, rook } => f.write_str(if king < rook { "O-O" } else { "O-O-O" }),
+            Self::Put { role, to } => {
                 if role != Role::Pawn {
                     f.write_char(role.upper_char())?;
                 }
@@ -226,8 +226,8 @@ pub enum CastlingSide {
 impl CastlingSide {
     pub const fn is_queen_side(self) -> bool {
         match self {
-            CastlingSide::KingSide => false,
-            CastlingSide::QueenSide => true,
+            Self::KingSide => false,
+            Self::QueenSide => true,
         }
     }
 
@@ -235,33 +235,33 @@ impl CastlingSide {
         !self.is_queen_side()
     }
 
-    pub const fn from_queen_side(queen_side: bool) -> CastlingSide {
+    pub const fn from_queen_side(queen_side: bool) -> Self {
         if queen_side {
-            CastlingSide::QueenSide
+            Self::QueenSide
         } else {
-            CastlingSide::KingSide
+            Self::KingSide
         }
     }
 
-    pub const fn from_king_side(king_side: bool) -> CastlingSide {
+    pub const fn from_king_side(king_side: bool) -> Self {
         if king_side {
-            CastlingSide::KingSide
+            Self::KingSide
         } else {
-            CastlingSide::QueenSide
+            Self::QueenSide
         }
     }
 
     pub const fn king_to_file(self) -> File {
         match self {
-            CastlingSide::KingSide => File::G,
-            CastlingSide::QueenSide => File::C,
+            Self::KingSide => File::G,
+            Self::QueenSide => File::C,
         }
     }
 
     pub const fn rook_to_file(self) -> File {
         match self {
-            CastlingSide::KingSide => File::F,
-            CastlingSide::QueenSide => File::D,
+            Self::KingSide => File::F,
+            Self::QueenSide => File::D,
         }
     }
 
@@ -274,7 +274,7 @@ impl CastlingSide {
     }
 
     /// `KingSide` and `QueenSide`, in this order.
-    pub const ALL: [CastlingSide; 2] = [CastlingSide::KingSide, CastlingSide::QueenSide];
+    pub const ALL: [Self; 2] = [Self::KingSide, Self::QueenSide];
 }
 
 /// `Standard` or `Chess960`.
@@ -285,28 +285,28 @@ pub enum CastlingMode {
 }
 
 impl CastlingMode {
-    pub const fn from_standard(standard: bool) -> CastlingMode {
+    pub const fn from_standard(standard: bool) -> Self {
         if standard {
-            CastlingMode::Standard
+            Self::Standard
         } else {
-            CastlingMode::Chess960
+            Self::Chess960
         }
     }
 
-    pub const fn from_chess960(chess960: bool) -> CastlingMode {
+    pub const fn from_chess960(chess960: bool) -> Self {
         if chess960 {
-            CastlingMode::Chess960
+            Self::Chess960
         } else {
-            CastlingMode::Standard
+            Self::Standard
         }
     }
 
     pub const fn is_standard(self) -> bool {
-        matches!(self, CastlingMode::Standard)
+        matches!(self, Self::Standard)
     }
 
     pub const fn is_chess960(self) -> bool {
-        matches!(self, CastlingMode::Chess960)
+        matches!(self, Self::Chess960)
     }
 }
 
@@ -369,8 +369,8 @@ mod tests {
 pub struct RemainingChecks(u32);
 
 impl Default for RemainingChecks {
-    fn default() -> RemainingChecks {
-        RemainingChecks(3)
+    fn default() -> Self {
+        Self(3)
     }
 }
 
@@ -380,9 +380,9 @@ impl RemainingChecks {
     /// # Panics
     ///
     /// Panics if `n > 3`.
-    pub const fn new(n: u32) -> RemainingChecks {
+    pub const fn new(n: u32) -> Self {
         assert!(n <= 3);
-        RemainingChecks(n)
+        Self(n)
     }
 
     pub const fn is_zero(self) -> bool {
@@ -390,8 +390,8 @@ impl RemainingChecks {
     }
 
     #[must_use]
-    pub const fn saturating_sub(self, n: u32) -> RemainingChecks {
-        RemainingChecks(self.0.saturating_sub(n))
+    pub const fn saturating_sub(self, n: u32) -> Self {
+        Self(self.0.saturating_sub(n))
     }
 }
 
@@ -399,8 +399,8 @@ macro_rules! int_from_remaining_checks_impl {
     ($($t:ty)+) => {
         $(impl From<RemainingChecks> for $t {
             #[inline]
-            fn from(RemainingChecks(checks): RemainingChecks) -> $t {
-                checks as $t
+            fn from(RemainingChecks(checks): RemainingChecks) -> Self {
+                checks as Self
             }
         })+
     }
@@ -414,10 +414,10 @@ macro_rules! try_remaining_checks_from_int_impl {
             type Error = num::TryFromIntError;
 
             #[inline]
-            fn try_from(value: $t) -> Result<RemainingChecks, Self::Error> {
+            fn try_from(value: $t) -> Result<Self, Self::Error> {
                 let n = u32::try_from(value)?;
                 if n <= 3 {
-                    Ok(RemainingChecks::new(n))
+                    Ok(Self::new(n))
                 } else {
                     Err(overflow_error())
                 }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -259,7 +259,7 @@ impl Uci {
     /// let uci = Uci::from_chess960(&m);
     /// assert_eq!(uci.to_string(), "e8h8");
     /// ```
-    pub fn from_chess960(m: &Move) -> Uci {
+    pub const fn from_chess960(m: &Move) -> Uci {
         match *m {
             Move::Normal {
                 from,

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -128,26 +128,26 @@ pub enum Uci {
 impl FromStr for Uci {
     type Err = ParseUciError;
 
-    fn from_str(uci: &str) -> Result<Uci, ParseUciError> {
-        Uci::from_ascii(uci.as_bytes())
+    fn from_str(uci: &str) -> Result<Self, ParseUciError> {
+        Self::from_ascii(uci.as_bytes())
     }
 }
 
 impl fmt::Display for Uci {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Uci::Normal {
+            Self::Normal {
                 from,
                 to,
                 promotion: None,
             } => write!(f, "{}{}", from, to),
-            Uci::Normal {
+            Self::Normal {
                 from,
                 to,
                 promotion: Some(promotion),
             } => write!(f, "{}{}{}", from, to, promotion.char()),
-            Uci::Put { to, role } => write!(f, "{}@{}", role.upper_char(), to),
-            Uci::Null => f.write_str("0000"),
+            Self::Put { to, role } => write!(f, "{}@{}", role.upper_char(), to),
+            Self::Null => f.write_str("0000"),
         }
     }
 }
@@ -174,38 +174,38 @@ impl Uci {
     ///
     /// # Ok::<_, shakmaty::uci::ParseUciError>(())
     /// ```
-    pub fn from_ascii(uci: &[u8]) -> Result<Uci, ParseUciError> {
+    pub fn from_ascii(uci: &[u8]) -> Result<Self, ParseUciError> {
         if uci.len() != 4 && uci.len() != 5 {
             return Err(ParseUciError);
         }
 
         if uci == b"0000" {
-            return Ok(Uci::Null);
+            return Ok(Self::Null);
         }
 
         let to = Square::from_ascii(&uci[2..4]).map_err(|_| ParseUciError)?;
 
-        if uci[1] == b'@' {
-            Ok(Uci::Put {
+        Ok(if uci[1] == b'@' {
+            Self::Put {
                 role: Role::from_char(char::from(uci[0])).ok_or(ParseUciError)?,
                 to,
-            })
+            }
         } else {
             let from = Square::from_ascii(&uci[0..2]).map_err(|_| ParseUciError)?;
             if uci.len() == 5 {
-                Ok(Uci::Normal {
+                Self::Normal {
                     from,
                     to,
                     promotion: Some(Role::from_char(char::from(uci[4])).ok_or(ParseUciError)?),
-                })
+                }
             } else {
-                Ok(Uci::Normal {
+                Self::Normal {
                     from,
                     to,
                     promotion: None,
-                })
+                }
             }
-        }
+        })
     }
 
     /// Converts a move to UCI notation. Castling moves are represented as
@@ -228,17 +228,17 @@ impl Uci {
     /// let uci = Uci::from_standard(&m);
     /// assert_eq!(uci.to_string(), "e8g8");
     /// ```
-    pub fn from_standard(m: &Move) -> Uci {
+    pub fn from_standard(m: &Move) -> Self {
         match *m {
             Move::Castle { king, rook } => {
                 let side = CastlingSide::from_king_side(king < rook);
-                Uci::Normal {
+                Self::Normal {
                     from: king,
                     to: Square::from_coords(side.king_to_file(), king.rank()),
                     promotion: None,
                 }
             }
-            _ => Uci::from_chess960(m),
+            _ => Self::from_chess960(m),
         }
     }
 
@@ -259,37 +259,37 @@ impl Uci {
     /// let uci = Uci::from_chess960(&m);
     /// assert_eq!(uci.to_string(), "e8h8");
     /// ```
-    pub const fn from_chess960(m: &Move) -> Uci {
+    pub const fn from_chess960(m: &Move) -> Self {
         match *m {
             Move::Normal {
                 from,
                 to,
                 promotion,
                 ..
-            } => Uci::Normal {
+            } => Self::Normal {
                 from,
                 to,
                 promotion,
             },
-            Move::EnPassant { from, to, .. } => Uci::Normal {
+            Move::EnPassant { from, to, .. } => Self::Normal {
                 from,
                 to,
                 promotion: None,
             },
-            Move::Castle { king, rook } => Uci::Normal {
+            Move::Castle { king, rook } => Self::Normal {
                 from: king,
                 to: rook,
                 promotion: None,
             }, // Chess960-style
-            Move::Put { role, to } => Uci::Put { role, to },
+            Move::Put { role, to } => Self::Put { role, to },
         }
     }
 
     /// See [`Uci::from_standard()`] or [`Uci::from_chess960()`].
-    pub fn from_move(m: &Move, mode: CastlingMode) -> Uci {
+    pub fn from_move(m: &Move, mode: CastlingMode) -> Self {
         match mode {
-            CastlingMode::Standard => Uci::from_standard(m),
-            CastlingMode::Chess960 => Uci::from_chess960(m),
+            CastlingMode::Standard => Self::from_standard(m),
+            CastlingMode::Chess960 => Self::from_chess960(m),
         }
     }
 
@@ -303,7 +303,7 @@ impl Uci {
     /// [`Move`]: super::Move
     pub fn to_move<P: Position>(&self, pos: &P) -> Result<Move, IllegalUciError> {
         let candidate = match *self {
-            Uci::Normal {
+            Self::Normal {
                 from,
                 to,
                 promotion,
@@ -350,8 +350,8 @@ impl Uci {
                     }
                 }
             }
-            Uci::Put { role, to } => Move::Put { role, to },
-            Uci::Null => return Err(IllegalUciError),
+            Self::Put { role, to } => Move::Put { role, to },
+            Self::Null => return Err(IllegalUciError),
         };
 
         if pos.is_legal(&candidate) {

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -58,52 +58,52 @@ impl Variant {
     /// of chess engines.
     pub const fn uci(self) -> &'static str {
         match self {
-            Variant::Chess => "chess",
-            Variant::Atomic => "atomic",
-            Variant::Antichess => "antichess",
-            Variant::KingOfTheHill => "kingofthehill",
-            Variant::ThreeCheck => "3check",
-            Variant::Crazyhouse => "crazyhouse",
-            Variant::RacingKings => "racingkings",
-            Variant::Horde => "horde",
+            Self::Chess => "chess",
+            Self::Atomic => "atomic",
+            Self::Antichess => "antichess",
+            Self::KingOfTheHill => "kingofthehill",
+            Self::ThreeCheck => "3check",
+            Self::Crazyhouse => "crazyhouse",
+            Self::RacingKings => "racingkings",
+            Self::Horde => "horde",
         }
     }
 
     /// Selects a variant based on the name used by the `UCI_Variant` option
     /// of chess engines.
-    pub fn from_uci(s: &str) -> Option<Variant> {
+    pub fn from_uci(s: &str) -> Option<Self> {
         Some(match s {
-            "chess" => Variant::Chess,
-            "atomic" => Variant::Atomic,
-            "antichess" => Variant::Antichess,
-            "kingofthehill" => Variant::KingOfTheHill,
-            "3check" => Variant::ThreeCheck,
-            "crazyhouse" => Variant::Crazyhouse,
-            "racingkings" => Variant::RacingKings,
-            "horde" => Variant::Horde,
+            "chess" => Self::Chess,
+            "atomic" => Self::Atomic,
+            "antichess" => Self::Antichess,
+            "kingofthehill" => Self::KingOfTheHill,
+            "3check" => Self::ThreeCheck,
+            "crazyhouse" => Self::Crazyhouse,
+            "racingkings" => Self::RacingKings,
+            "horde" => Self::Horde,
             _ => return None,
         })
     }
 
     pub fn distinguishes_promoted(self) -> bool {
-        matches!(self, Variant::Crazyhouse)
+        matches!(self, Self::Crazyhouse)
     }
 
-    pub const ALL: [Variant; 8] = [
-        Variant::Chess,
-        Variant::Atomic,
-        Variant::Antichess,
-        Variant::KingOfTheHill,
-        Variant::ThreeCheck,
-        Variant::Crazyhouse,
-        Variant::RacingKings,
-        Variant::Horde,
+    pub const ALL: [Self; 8] = [
+        Self::Chess,
+        Self::Atomic,
+        Self::Antichess,
+        Self::KingOfTheHill,
+        Self::ThreeCheck,
+        Self::Crazyhouse,
+        Self::RacingKings,
+        Self::Horde,
     ];
 }
 
 impl Default for Variant {
-    fn default() -> Variant {
-        Variant::Chess
+    fn default() -> Self {
+        Self::Chess
     }
 }
 
@@ -122,55 +122,55 @@ pub enum VariantPosition {
 }
 
 impl From<Chess> for VariantPosition {
-    fn from(pos: Chess) -> VariantPosition {
-        VariantPosition::Chess(pos)
+    fn from(pos: Chess) -> Self {
+        Self::Chess(pos)
     }
 }
 
 impl From<Atomic> for VariantPosition {
-    fn from(pos: Atomic) -> VariantPosition {
-        VariantPosition::Atomic(pos)
+    fn from(pos: Atomic) -> Self {
+        Self::Atomic(pos)
     }
 }
 
 impl From<Antichess> for VariantPosition {
-    fn from(pos: Antichess) -> VariantPosition {
-        VariantPosition::Antichess(pos)
+    fn from(pos: Antichess) -> Self {
+        Self::Antichess(pos)
     }
 }
 
 impl From<KingOfTheHill> for VariantPosition {
-    fn from(pos: KingOfTheHill) -> VariantPosition {
-        VariantPosition::KingOfTheHill(pos)
+    fn from(pos: KingOfTheHill) -> Self {
+        Self::KingOfTheHill(pos)
     }
 }
 
 impl From<ThreeCheck> for VariantPosition {
-    fn from(pos: ThreeCheck) -> VariantPosition {
-        VariantPosition::ThreeCheck(pos)
+    fn from(pos: ThreeCheck) -> Self {
+        Self::ThreeCheck(pos)
     }
 }
 
 impl From<Crazyhouse> for VariantPosition {
-    fn from(pos: Crazyhouse) -> VariantPosition {
-        VariantPosition::Crazyhouse(pos)
+    fn from(pos: Crazyhouse) -> Self {
+        Self::Crazyhouse(pos)
     }
 }
 
 impl From<RacingKings> for VariantPosition {
-    fn from(pos: RacingKings) -> VariantPosition {
-        VariantPosition::RacingKings(pos)
+    fn from(pos: RacingKings) -> Self {
+        Self::RacingKings(pos)
     }
 }
 
 impl From<Horde> for VariantPosition {
-    fn from(pos: Horde) -> VariantPosition {
-        VariantPosition::Horde(pos)
+    fn from(pos: Horde) -> Self {
+        Self::Horde(pos)
     }
 }
 
 impl VariantPosition {
-    pub fn new(variant: Variant) -> VariantPosition {
+    pub fn new(variant: Variant) -> Self {
         match variant {
             Variant::Chess => Chess::default().into(),
             Variant::Atomic => Atomic::default().into(),
@@ -187,7 +187,7 @@ impl VariantPosition {
         variant: Variant,
         setup: Setup,
         mode: CastlingMode,
-    ) -> Result<VariantPosition, PositionError<VariantPosition>> {
+    ) -> Result<Self, PositionError<Self>> {
         fn wrap<F, P, U>(result: Result<P, PositionError<P>>, f: F) -> Result<U, PositionError<U>>
         where
             F: FnOnce(P) -> U,
@@ -228,50 +228,50 @@ impl VariantPosition {
         }
     }
 
-    pub fn swap_turn(self) -> Result<VariantPosition, PositionError<VariantPosition>> {
+    pub fn swap_turn(self) -> Result<Self, PositionError<Self>> {
         let mode = self.castles().mode();
         let variant = self.variant();
         let mut setup = self.into_setup(EnPassantMode::Always);
         setup.swap_turn();
-        VariantPosition::from_setup(variant, setup, mode)
+        Self::from_setup(variant, setup, mode)
     }
 
     pub fn variant(&self) -> Variant {
         match self {
-            VariantPosition::Chess(_) => Variant::Chess,
-            VariantPosition::Atomic(_) => Variant::Atomic,
-            VariantPosition::Antichess(_) => Variant::Antichess,
-            VariantPosition::KingOfTheHill(_) => Variant::KingOfTheHill,
-            VariantPosition::ThreeCheck(_) => Variant::ThreeCheck,
-            VariantPosition::Crazyhouse(_) => Variant::Crazyhouse,
-            VariantPosition::RacingKings(_) => Variant::RacingKings,
-            VariantPosition::Horde(_) => Variant::Horde,
+            Self::Chess(_) => Variant::Chess,
+            Self::Atomic(_) => Variant::Atomic,
+            Self::Antichess(_) => Variant::Antichess,
+            Self::KingOfTheHill(_) => Variant::KingOfTheHill,
+            Self::ThreeCheck(_) => Variant::ThreeCheck,
+            Self::Crazyhouse(_) => Variant::Crazyhouse,
+            Self::RacingKings(_) => Variant::RacingKings,
+            Self::Horde(_) => Variant::Horde,
         }
     }
 
     fn borrow(&self) -> &dyn Position {
         match *self {
-            VariantPosition::Chess(ref pos) => pos,
-            VariantPosition::Atomic(ref pos) => pos,
-            VariantPosition::Antichess(ref pos) => pos,
-            VariantPosition::KingOfTheHill(ref pos) => pos,
-            VariantPosition::ThreeCheck(ref pos) => pos,
-            VariantPosition::Crazyhouse(ref pos) => pos,
-            VariantPosition::RacingKings(ref pos) => pos,
-            VariantPosition::Horde(ref pos) => pos,
+            Self::Chess(ref pos) => pos,
+            Self::Atomic(ref pos) => pos,
+            Self::Antichess(ref pos) => pos,
+            Self::KingOfTheHill(ref pos) => pos,
+            Self::ThreeCheck(ref pos) => pos,
+            Self::Crazyhouse(ref pos) => pos,
+            Self::RacingKings(ref pos) => pos,
+            Self::Horde(ref pos) => pos,
         }
     }
 
     fn borrow_mut(&mut self) -> &mut dyn Position {
         match *self {
-            VariantPosition::Chess(ref mut pos) => pos,
-            VariantPosition::Atomic(ref mut pos) => pos,
-            VariantPosition::Antichess(ref mut pos) => pos,
-            VariantPosition::KingOfTheHill(ref mut pos) => pos,
-            VariantPosition::ThreeCheck(ref mut pos) => pos,
-            VariantPosition::Crazyhouse(ref mut pos) => pos,
-            VariantPosition::RacingKings(ref mut pos) => pos,
-            VariantPosition::Horde(ref mut pos) => pos,
+            Self::Chess(ref mut pos) => pos,
+            Self::Atomic(ref mut pos) => pos,
+            Self::Antichess(ref mut pos) => pos,
+            Self::KingOfTheHill(ref mut pos) => pos,
+            Self::ThreeCheck(ref mut pos) => pos,
+            Self::Crazyhouse(ref mut pos) => pos,
+            Self::RacingKings(ref mut pos) => pos,
+            Self::Horde(ref mut pos) => pos,
         }
     }
 }
@@ -315,14 +315,14 @@ impl Position for VariantPosition {
 
     fn into_setup(self, mode: EnPassantMode) -> Setup {
         match self {
-            VariantPosition::Chess(pos) => pos.into_setup(mode),
-            VariantPosition::Atomic(pos) => pos.into_setup(mode),
-            VariantPosition::Antichess(pos) => pos.into_setup(mode),
-            VariantPosition::KingOfTheHill(pos) => pos.into_setup(mode),
-            VariantPosition::ThreeCheck(pos) => pos.into_setup(mode),
-            VariantPosition::Horde(pos) => pos.into_setup(mode),
-            VariantPosition::RacingKings(pos) => pos.into_setup(mode),
-            VariantPosition::Crazyhouse(pos) => pos.into_setup(mode),
+            Self::Chess(pos) => pos.into_setup(mode),
+            Self::Atomic(pos) => pos.into_setup(mode),
+            Self::Antichess(pos) => pos.into_setup(mode),
+            Self::KingOfTheHill(pos) => pos.into_setup(mode),
+            Self::ThreeCheck(pos) => pos.into_setup(mode),
+            Self::Horde(pos) => pos.into_setup(mode),
+            Self::RacingKings(pos) => pos.into_setup(mode),
+            Self::Crazyhouse(pos) => pos.into_setup(mode),
         }
     }
     fn legal_moves(&self) -> MoveList {
@@ -377,14 +377,14 @@ impl Position for VariantPosition {
 impl ZobristHash for VariantPosition {
     fn zobrist_hash<V: ZobristValue>(&self) -> V {
         match self {
-            VariantPosition::Chess(pos) => pos.zobrist_hash(),
-            VariantPosition::Atomic(pos) => pos.zobrist_hash(),
-            VariantPosition::Antichess(pos) => pos.zobrist_hash(),
-            VariantPosition::KingOfTheHill(pos) => pos.zobrist_hash(),
-            VariantPosition::ThreeCheck(pos) => pos.zobrist_hash(),
-            VariantPosition::Crazyhouse(pos) => pos.zobrist_hash(),
-            VariantPosition::RacingKings(pos) => pos.zobrist_hash(),
-            VariantPosition::Horde(pos) => pos.zobrist_hash(),
+            Self::Chess(pos) => pos.zobrist_hash(),
+            Self::Atomic(pos) => pos.zobrist_hash(),
+            Self::Antichess(pos) => pos.zobrist_hash(),
+            Self::KingOfTheHill(pos) => pos.zobrist_hash(),
+            Self::ThreeCheck(pos) => pos.zobrist_hash(),
+            Self::Crazyhouse(pos) => pos.zobrist_hash(),
+            Self::RacingKings(pos) => pos.zobrist_hash(),
+            Self::Horde(pos) => pos.zobrist_hash(),
         }
     }
 
@@ -394,16 +394,16 @@ impl ZobristHash for VariantPosition {
         m: &Move,
     ) -> Option<V> {
         match self {
-            VariantPosition::Chess(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
-            VariantPosition::Atomic(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
-            VariantPosition::Antichess(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
-            VariantPosition::KingOfTheHill(pos) => {
+            Self::Chess(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
+            Self::Atomic(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
+            Self::Antichess(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
+            Self::KingOfTheHill(pos) => {
                 pos.prepare_incremental_zobrist_hash(previous, m)
             }
-            VariantPosition::ThreeCheck(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
-            VariantPosition::Crazyhouse(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
-            VariantPosition::RacingKings(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
-            VariantPosition::Horde(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
+            Self::ThreeCheck(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
+            Self::Crazyhouse(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
+            Self::RacingKings(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
+            Self::Horde(pos) => pos.prepare_incremental_zobrist_hash(previous, m),
         }
     }
 
@@ -413,24 +413,24 @@ impl ZobristHash for VariantPosition {
         m: &Move,
     ) -> Option<V> {
         match self {
-            VariantPosition::Chess(pos) => pos.finalize_incremental_zobrist_hash(intermediate, m),
-            VariantPosition::Atomic(pos) => pos.finalize_incremental_zobrist_hash(intermediate, m),
-            VariantPosition::Antichess(pos) => {
+            Self::Chess(pos) => pos.finalize_incremental_zobrist_hash(intermediate, m),
+            Self::Atomic(pos) => pos.finalize_incremental_zobrist_hash(intermediate, m),
+            Self::Antichess(pos) => {
                 pos.finalize_incremental_zobrist_hash(intermediate, m)
             }
-            VariantPosition::KingOfTheHill(pos) => {
+            Self::KingOfTheHill(pos) => {
                 pos.finalize_incremental_zobrist_hash(intermediate, m)
             }
-            VariantPosition::ThreeCheck(pos) => {
+            Self::ThreeCheck(pos) => {
                 pos.finalize_incremental_zobrist_hash(intermediate, m)
             }
-            VariantPosition::Crazyhouse(pos) => {
+            Self::Crazyhouse(pos) => {
                 pos.finalize_incremental_zobrist_hash(intermediate, m)
             }
-            VariantPosition::RacingKings(pos) => {
+            Self::RacingKings(pos) => {
                 pos.finalize_incremental_zobrist_hash(intermediate, m)
             }
-            VariantPosition::Horde(pos) => pos.finalize_incremental_zobrist_hash(intermediate, m),
+            Self::Horde(pos) => pos.finalize_incremental_zobrist_hash(intermediate, m),
         }
     }
 }

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -56,7 +56,7 @@ pub enum Variant {
 impl Variant {
     /// Gets the name of the variant, as expected by the `UCI_Variant` option
     /// of chess engines.
-    pub fn uci(self) -> &'static str {
+    pub const fn uci(self) -> &'static str {
         match self {
             Variant::Chess => "chess",
             Variant::Atomic => "atomic",
@@ -86,7 +86,7 @@ impl Variant {
     }
 
     pub fn distinguishes_promoted(self) -> bool {
-        self == Variant::Crazyhouse
+        matches!(self, Variant::Crazyhouse)
     }
 
     pub const ALL: [Variant; 8] = [
@@ -280,30 +280,39 @@ impl Position for VariantPosition {
     fn board(&self) -> &Board {
         self.borrow().board()
     }
+
     fn promoted(&self) -> Bitboard {
         self.borrow().promoted()
     }
+
     fn pockets(&self) -> Option<&ByColor<ByRole<u8>>> {
         self.borrow().pockets()
     }
+
     fn turn(&self) -> Color {
         self.borrow().turn()
     }
+
     fn castles(&self) -> &Castles {
         self.borrow().castles()
     }
+
     fn maybe_ep_square(&self) -> Option<Square> {
         self.borrow().maybe_ep_square()
     }
+
     fn remaining_checks(&self) -> Option<&ByColor<RemainingChecks>> {
         self.borrow().remaining_checks()
     }
+
     fn halfmoves(&self) -> u32 {
         self.borrow().halfmoves()
     }
+
     fn fullmoves(&self) -> NonZeroU32 {
         self.borrow().fullmoves()
     }
+
     fn into_setup(self, mode: EnPassantMode) -> Setup {
         match self {
             VariantPosition::Chess(pos) => pos.into_setup(mode),
@@ -319,36 +328,47 @@ impl Position for VariantPosition {
     fn legal_moves(&self) -> MoveList {
         self.borrow().legal_moves()
     }
+
     fn san_candidates(&self, role: Role, to: Square) -> MoveList {
         self.borrow().san_candidates(role, to)
     }
+
     fn castling_moves(&self, side: CastlingSide) -> MoveList {
         self.borrow().castling_moves(side)
     }
+
     fn en_passant_moves(&self) -> MoveList {
         self.borrow().en_passant_moves()
     }
+
     fn capture_moves(&self) -> MoveList {
         self.borrow().capture_moves()
     }
+
     fn promotion_moves(&self) -> MoveList {
         self.borrow().promotion_moves()
     }
+
     fn is_irreversible(&self, m: &Move) -> bool {
         self.borrow().is_irreversible(m)
     }
+
     fn king_attackers(&self, square: Square, attacker: Color, occupied: Bitboard) -> Bitboard {
         self.borrow().king_attackers(square, attacker, occupied)
     }
+
     fn is_variant_end(&self) -> bool {
         self.borrow().is_variant_end()
     }
+
     fn has_insufficient_material(&self, color: Color) -> bool {
         self.borrow().has_insufficient_material(color)
     }
+
     fn variant_outcome(&self) -> Option<Outcome> {
         self.borrow().variant_outcome()
     }
+
     fn play_unchecked(&mut self, m: &Move) {
         self.borrow_mut().play_unchecked(m)
     }

--- a/src/zobrist.rs
+++ b/src/zobrist.rs
@@ -53,48 +53,48 @@ pub trait ZobristValue: BitXorAssign + Default + Copy {
 macro_rules! zobrist_value_impl {
     ($($t:ty)+) => {
         $(impl ZobristValue for $t {
-            fn zobrist_for_piece(square: Square, piece: Piece) -> $t {
+            fn zobrist_for_piece(square: Square, piece: Piece) -> Self {
                 let piece_idx = (usize::from(piece.role) - 1) * 2 + piece.color as usize;
-                PIECE_MASKS[64 * piece_idx + usize::from(square)] as $t
+                PIECE_MASKS[64 * piece_idx + usize::from(square)] as Self
             }
 
-            fn zobrist_for_white_turn() -> $t {
-                WHITE_TURN_MASK as $t
+            fn zobrist_for_white_turn() -> Self {
+                WHITE_TURN_MASK as Self
             }
 
-            fn zobrist_for_castling_right(color: Color, side: CastlingSide) -> $t {
+            fn zobrist_for_castling_right(color: Color, side: CastlingSide) -> Self {
                 CASTLING_RIGHT_MASKS[match (color, side) {
                     (Color::White, CastlingSide::KingSide) => 0,
                     (Color::White, CastlingSide::QueenSide) => 1,
                     (Color::Black, CastlingSide::KingSide) => 2,
                     (Color::Black, CastlingSide::QueenSide) => 3,
-                }] as $t
+                }] as Self
             }
 
-            fn zobrist_for_en_passant_file(file: File) -> $t {
-                EN_PASSANT_FILE_MASKS[usize::from(file)] as $t
+            fn zobrist_for_en_passant_file(file: File) -> Self {
+                EN_PASSANT_FILE_MASKS[usize::from(file)] as Self
             }
 
-            fn zobrist_for_remaining_checks(color: Color, remaining: RemainingChecks) -> $t {
+            fn zobrist_for_remaining_checks(color: Color, remaining: RemainingChecks) -> Self {
                 if remaining < RemainingChecks::default() {
-                    REMAINING_CHECKS_MASKS[usize::from(remaining) + color.fold_wb(0, 3)] as $t
+                    REMAINING_CHECKS_MASKS[usize::from(remaining) + color.fold_wb(0, 3)] as Self
                 } else {
-                    <$t>::default()
+                    Self::default()
                 }
             }
 
-            fn zobrist_for_promoted(square: Square) -> $t {
-                PROMOTED_MASKS[usize::from(square)] as $t
+            fn zobrist_for_promoted(square: Square) -> Self {
+                PROMOTED_MASKS[usize::from(square)] as Self
             }
 
-            fn zobrist_for_pocket(color: Color, role: Role, pieces: u8) -> $t {
+            fn zobrist_for_pocket(color: Color, role: Role, pieces: u8) -> Self {
                 if 0 < pieces && pieces <= 16 {
                     let color_idx = color as usize;
                     let role_idx = usize::from(role) - 1;
                     let pieces_idx = usize::from(pieces) - 1;
-                    POCKET_MASKS[color_idx * 6 * 16 + role_idx * 16 + pieces_idx] as $t
+                    POCKET_MASKS[color_idx * 6 * 16 + role_idx * 16 + pieces_idx] as Self
                 } else {
-                    <$t>::default()
+                    Self::default()
                 }
             }
         })+
@@ -224,8 +224,8 @@ pub struct Zobrist<P, V: ZobristValue> {
 }
 
 impl<P, V: ZobristValue> Zobrist<P, V> {
-    pub fn new(pos: P) -> Zobrist<P, V> {
-        Zobrist {
+    pub fn new(pos: P) -> Self {
+        Self {
             pos,
             zobrist: Cell::new(None),
         }
@@ -253,7 +253,7 @@ impl<P: ZobristHash, V: ZobristValue> Zobrist<P, V> {
 }
 
 impl<P: Default, V: ZobristValue> Default for Zobrist<P, V> {
-    fn default() -> Zobrist<P, V> {
+    fn default() -> Self {
         Self::new(P::default())
     }
 }
@@ -261,9 +261,9 @@ impl<P: Default, V: ZobristValue> Default for Zobrist<P, V> {
 impl<P: FromSetup + Position, V: ZobristValue> FromSetup for Zobrist<P, V> {
     fn from_setup(setup: Setup, mode: CastlingMode) -> Result<Self, PositionError<Self>> {
         match P::from_setup(setup, mode) {
-            Ok(pos) => Ok(Zobrist::new(pos)),
+            Ok(pos) => Ok(Self::new(pos)),
             Err(err) => Err(PositionError {
-                pos: Zobrist::new(err.pos),
+                pos: Self::new(err.pos),
                 errors: err.errors,
             }),
         }
@@ -274,63 +274,83 @@ impl<P: Position + ZobristHash, V: ZobristValue> Position for Zobrist<P, V> {
     fn board(&self) -> &Board {
         self.pos.board()
     }
+
     fn promoted(&self) -> Bitboard {
         self.pos.promoted()
     }
+
     fn pockets(&self) -> Option<&ByColor<ByRole<u8>>> {
         self.pos.pockets()
     }
+
     fn turn(&self) -> Color {
         self.pos.turn()
     }
+
     fn castles(&self) -> &Castles {
         self.pos.castles()
     }
+
     fn maybe_ep_square(&self) -> Option<Square> {
         self.pos.maybe_ep_square()
     }
+
     fn remaining_checks(&self) -> Option<&ByColor<RemainingChecks>> {
         self.pos.remaining_checks()
     }
+
     fn halfmoves(&self) -> u32 {
         self.pos.halfmoves()
     }
+
     fn fullmoves(&self) -> NonZeroU32 {
         self.pos.fullmoves()
     }
+
     fn into_setup(self, mode: EnPassantMode) -> Setup {
         self.pos.into_setup(mode)
     }
+
     fn legal_moves(&self) -> MoveList {
         self.pos.legal_moves()
     }
+
     fn san_candidates(&self, role: Role, to: Square) -> MoveList {
         self.pos.san_candidates(role, to)
     }
+
     fn castling_moves(&self, side: CastlingSide) -> MoveList {
         self.pos.castling_moves(side)
     }
+
     fn en_passant_moves(&self) -> MoveList {
         self.pos.en_passant_moves()
     }
+
     fn capture_moves(&self) -> MoveList {
         self.pos.capture_moves()
     }
+
     fn promotion_moves(&self) -> MoveList {
         self.pos.promotion_moves()
     }
+
     fn is_irreversible(&self, m: &Move) -> bool {
         self.pos.is_irreversible(m)
     }
+
     fn king_attackers(&self, square: Square, attacker: Color, occupied: Bitboard) -> Bitboard {
         self.pos.king_attackers(square, attacker, occupied)
     }
+
     fn is_variant_end(&self) -> bool {
         self.pos.is_variant_end()
     }
+
     fn has_insufficient_material(&self, color: Color) -> bool {
         self.pos.has_insufficient_material(color)
     }
+
     fn variant_outcome(&self) -> Option<Outcome> {
         self.pos.variant_outcome()
     }


### PR DESCRIPTION
... well, okay, maybe not _all_ the things. Methods that take in `&mut self` are not _yet_ eligible for `const`-ification. This PR does manage to `const`-ify many things, though. 🥳

# `const`-ified Methods
For most methods, adding a `const` declaration was trivial since the compiler already supported the operations within. The rest required some extra massaging around `const` traits—or lack thereof.

In particular, many `Bitboard` operations may actually be `const`-ified if it weren't for non-`const` traits such as `From`, `Into`, `Add`, `Sub`, `BitOr`, `BitAnd`, etc. To resolve this, I've added `*_const` variants for these operations in the `impl Bitboard` itself.

The `const`-ification cascaded upwards to all dependent `struct`s from that point forward. It was actually fascinating to see how most of the tests immediately finish.

```rust
impl Bitboard {
    // ... and more!

    pub fn is_disjoint<T: Into<Self>>(self, other: T) -> Self { ... }
    pub const fn is_disjoint_const(self, other: Self) -> Self { ... }

    pub fn is_subset<T: Into<Self>>(self, other: T) -> Self { ... }
    pub const fn is_subset_const(self, other: Self) -> Self { ... }

    pub fn is_superset<T: Into<Self>>(self, other: T) -> Self { ... }
    pub const fn is_superset_const(self, other: Self) -> Self { ... }

    // ... and more!
}
```

# MSRV Bump
All the `const`-ification required one MSRV bump from `1.60` to `1.61`. The specific feature for which `const` stabilization is required is the [`pointer::offset`](https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.offset) method.

# Clippy: Prefer `Self` Alias
While I was fixing up the methods, I also decided to use the `Self` alias in various methods wherever possible (instead of explicitly naming the concrete `Self`). This should lessen unnecessary repetition of `struct` names.