### PR TITLE
add serialization / deserialization support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ bitflags = "2.0.0"
 btoi = "0.4"
 arrayvec = { version = "0.7", default-features = false }
 nohash-hasher = { version = "0.2", optional = true }
+serde = { version = "1.0", features = ["derive"] }
+
+[build-dependencies]
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 iai = "0.1"

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -23,6 +23,8 @@ use core::{
     ops,
 };
 
+use serde::{Serialize, Deserialize};
+
 use crate::square::{File, Rank, Square};
 
 /// A set of [squares](super::Square) represented by a 64 bit
@@ -43,7 +45,7 @@ use crate::square::{File, Rank, Square};
 /// // . 1 . . 1 . . .
 /// // . 1 . . . 1 . .
 /// ```
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
 pub struct Bitboard(pub u64);
 
 impl Bitboard {

--- a/src/board.rs
+++ b/src/board.rs
@@ -22,6 +22,8 @@ use core::{
     iter::{FromIterator, FusedIterator},
 };
 
+use serde::{Serialize, Deserialize};
+
 use crate::{attacks, Bitboard, ByColor, ByRole, Color, File, Piece, Rank, Role, Square};
 
 /// [`Piece`] positions on a board.
@@ -43,7 +45,7 @@ use crate::{attacks, Bitboard, ByColor, ByRole, Color, File, Piece, Rank, Role, 
 ///
 /// assert_eq!(board.piece_at(Square::E8), Some(Black.king()));
 /// ```
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Board {
     by_role: ByRole<Bitboard>,
     by_color: ByColor<Bitboard>,

--- a/src/color.rs
+++ b/src/color.rs
@@ -18,6 +18,8 @@
 
 use core::{array, convert::identity, fmt, mem, ops, str::FromStr};
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
     role::{ByRole, Role},
     square::Rank,
@@ -26,7 +28,7 @@ use crate::{
 
 /// `White` or `Black`.
 #[allow(missing_docs)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Serialize, Deserialize)]
 pub enum Color {
     Black = 0,
     White = 1,
@@ -200,7 +202,7 @@ impl FromStr for Color {
 }
 
 /// Container with values for each [`Color`].
-#[derive(Copy, Clone, Default, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Debug, Hash, Deserialize, Serialize)]
 #[repr(C)]
 pub struct ByColor<T> {
     pub black: T,

--- a/src/position.rs
+++ b/src/position.rs
@@ -1009,6 +1009,7 @@ impl Position for Chess {
 #[cfg(feature = "variant")]
 pub(crate) mod variant {
     use core::{cmp::min, ops::Not};
+    use serde::{Deserialize, Serialize};
 
     use super::*;
 
@@ -1303,7 +1304,7 @@ pub(crate) mod variant {
 
     /// An Antichess position. Antichess is also known as Giveaway, but players
     /// start without castling rights.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, Serialize, Deserialize)]
     pub struct Antichess {
         board: Board,
         turn: Color,

--- a/src/role.rs
+++ b/src/role.rs
@@ -16,6 +16,8 @@
 
 use core::{array, convert::identity, num};
 
+use serde::{Serialize, Deserialize};
+
 use crate::{color::Color, types::Piece, util::overflow_error};
 
 /// Piece types: `Pawn`, `Knight`, `Bishop`, `Rook`, `Queen`, `King`.
@@ -186,7 +188,7 @@ macro_rules! try_role_from_int_impl {
 try_role_from_int_impl! { u8 i8 u16 i16 u32 i32 u64 i64 usize isize }
 
 /// Container with values for each [`Role`].
-#[derive(Copy, Clone, Default, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Debug, Hash, Serialize, Deserialize)]
 #[repr(C)]
 pub struct ByRole<T> {
     pub pawn: T,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -16,6 +16,8 @@
 
 use core::{convert::identity, num::NonZeroU32};
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
     attacks, Bitboard, Board, ByColor, ByRole, CastlingMode, CastlingSide, Color, File, FromSetup,
     PositionError, Rank, RemainingChecks, Square,
@@ -138,7 +140,7 @@ impl Default for Setup {
 }
 
 /// Castling paths and unmoved rooks.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Castles {
     mask: Bitboard,
     rook: ByColor<[Option<Square>; 2]>,
@@ -339,7 +341,7 @@ impl Castles {
 }
 
 /// En passant square on the third or sixth rank.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) struct EnPassant(pub Square);
 
 impl From<EnPassant> for Square {

--- a/src/square.rs
+++ b/src/square.rs
@@ -24,6 +24,8 @@ use core::{
     str,
 };
 
+use serde::{Serialize, Deserialize};
+
 use crate::util::overflow_error;
 
 macro_rules! from_repr_u8_impl {
@@ -351,7 +353,7 @@ impl std::error::Error for ParseSquareError {}
 /// A square of the chessboard.
 #[rustfmt::skip]
 #[allow(missing_docs)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum Square {
     A1 = 0, B1, C1, D1, E1, F1, G1, H1,

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,6 +19,8 @@ use core::{
     num,
 };
 
+use serde::{Serialize, Deserialize};
+
 use crate::{
     color::{ByColor, Color},
     role::Role,
@@ -276,7 +278,7 @@ impl CastlingSide {
 }
 
 /// `Standard` or `Chess960`.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, Serialize, Deserialize)]
 pub enum CastlingMode {
     Standard,
     Chess960,


### PR DESCRIPTION
With the support of serialization / deserialization, instances can be sent over wire.

Use Case:
- you have a chess instance,
- you want to send this instance to another service (a pub/sub service can be used)
- you can serialize the instance and then send it
- you can fetch the instance on the other end, and deserialize it and you can use it