### PR TITLE
refactor(uci): rename Uci to UciMove

### DIFF
--- a/fuzz/fuzz_targets/uci.rs
+++ b/fuzz/fuzz_targets/uci.rs
@@ -1,11 +1,11 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use shakmaty::uci::Uci;
+use shakmaty::uci::UciMove;
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(uci) = Uci::from_ascii(data) {
-        let roundtripped = Uci::from_ascii(uci.to_string().as_bytes()).expect("roundtrip");
+    if let Ok(uci) = UciMove::from_ascii(data) {
+        let roundtripped = UciMove::from_ascii(uci.to_string().as_bytes()).expect("roundtrip");
         assert_eq!(uci, roundtripped);
     }
 });


### PR DESCRIPTION
Also rename associated errors: `ParseUciError` → `ParseUciMoveError` and `IllegalUciError` → `IllegalUciMoveError`

---

For context, I’m working on adding an `UciMessage` enum, similar to [vampirc-uci](https://github.com/vampirc/vampirc-uci) and I found the name `Uci` confusing.

This is backward compatible thanks to type aliasing, but it’ll raise deprecation warning at compile time for users of that crate.