### PR TITLE
Fixed `no_std` compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ bench = false
 
 [dependencies]
 bitflags = "2.0.0"
-btoi = "0.4"
+btoi = { version = "0.4", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
 nohash-hasher = { version = "0.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.75" # remember to update test.yml
 [features]
 default = ["std"]
 alloc = []
-std = ["alloc"]
+std = ["alloc", "btoi/std"]
 variant = []
 nohash-hasher = ["dep:nohash-hasher"]
 


### PR DESCRIPTION
- Disabled `std` default feature for `btoi` dep and added missing `std` feature mapping

It makes possible to compile project under `no_std` flag.