### PR TITLE
Serde for the most "natural" types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ bitflags = "2.0.0"
 btoi = { version = "0.4", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
 nohash-hasher = { version = "0.2", default-features = false, optional = true }
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
 
 [dev-dependencies]
 csv = "1.3"

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -580,6 +580,28 @@ impl Display for Fen {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for Fen {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&alloc::string::ToString::to_string(self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Fen {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let str = alloc::string::String::deserialize(deserializer)?;
+
+        Self::from_str(&str).map_err(serde::de::Error::custom)
+    }
+}
+
 /// An EPD like `rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -`.
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
 pub struct Epd(Setup);
@@ -661,6 +683,28 @@ impl FromStr for Epd {
 impl Display for Epd {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.append_to(f)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Epd {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&alloc::string::ToString::to_string(self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Epd {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let str = alloc::string::String::deserialize(deserializer)?;
+
+        Self::from_str(&str).map_err(serde::de::Error::custom)
     }
 }
 

--- a/src/san.rs
+++ b/src/san.rs
@@ -543,6 +543,28 @@ impl fmt::Display for San {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for San {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&alloc::string::ToString::to_string(self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for San {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let str = alloc::string::String::deserialize(deserializer)?;
+
+        Self::from_str(&str).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Check (`+`) or checkmate (`#`) suffix.
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
 pub enum Suffix {
@@ -679,6 +701,28 @@ impl FromStr for SanPlus {
 impl fmt::Display for SanPlus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.append_to(f)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for SanPlus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&alloc::string::ToString::to_string(self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for SanPlus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let str = alloc::string::String::deserialize(deserializer)?;
+
+        Self::from_str(&str).map_err(serde::de::Error::custom)
     }
 }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -132,6 +132,28 @@ impl fmt::Display for UciMove {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for UciMove {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&alloc::string::ToString::to_string(self))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for UciMove {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let str = alloc::string::String::deserialize(deserializer)?;
+
+        Self::from_str(&str).map_err(serde::de::Error::custom)
+    }
+}
+
 impl UciMove {
     /// Parses a move in UCI notation.
     ///


### PR DESCRIPTION
Adds `Serialize` and `Deserialize` for the types explicitly approved in #86:

- `San`
- `SanPlus`
- `UciMove`
- `Fen`
- `Epd`