### PR TITLE
Add `Copy` for small types

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -55,7 +55,7 @@ fn bench_play_unchecked() -> Chess {
     };
 
     let mut pos = black_box(pos);
-    pos.play_unchecked(&m);
+    pos.play_unchecked(m);
     pos
 }
 
@@ -92,7 +92,7 @@ fn bench_play_sans() -> Chess {
             .to_move(&pos)
             .expect("legal move");
 
-        pos.play_unchecked(&m);
+        pos.play_unchecked(m);
     }
     pos
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -351,8 +351,8 @@ impl<T> ByColor<ByRole<T>> {
 
 #[cfg(feature = "variant")]
 impl ByColor<ByRole<u8>> {
-    pub(crate) fn count(&self) -> usize {
-        self.iter().map(ByRole::count).sum()
+    pub(crate) fn count(self) -> usize {
+        self.iter().map(|&role| role.count()).sum()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! # let pos = Chess::default();
 //!
 //! // 1. e4
-//! let pos = pos.play(&Move::Normal {
+//! let pos = pos.play(Move::Normal {
 //!     role: Role::Pawn,
 //!     from: Square::E2,
 //!     to: Square::E4,

--- a/src/perft.rs
+++ b/src/perft.rs
@@ -36,7 +36,7 @@ pub fn perft<P: Position + Clone>(pos: &P, depth: u32) -> u64 {
         } else {
             moves
                 .iter()
-                .map(|m| {
+                .map(|&m| {
                     let mut child = pos.clone();
                     child.play_unchecked(m);
                     perft(&child, depth - 1)

--- a/src/position.rs
+++ b/src/position.rs
@@ -667,7 +667,7 @@ pub struct Chess {
 
 impl Chess {
     #[cfg(feature = "variant")]
-    fn gives_check(&self, m: &Move) -> bool {
+    fn gives_check(&self, m: Move) -> bool {
         let mut pos = self.clone();
         pos.play_unchecked(m);
         pos.is_check()
@@ -1198,7 +1198,7 @@ pub(crate) mod variant {
             }
         }
 
-        fn play_unchecked(&mut self, m: &Move) {
+        fn play_unchecked(&mut self, m: Move) {
             do_move(
                 &mut self.board,
                 &mut Bitboard(0),
@@ -1210,7 +1210,7 @@ pub(crate) mod variant {
                 m,
             );
 
-            match *m {
+            match m {
                 Move::Normal {
                     capture: Some(_),
                     to,
@@ -1262,7 +1262,7 @@ pub(crate) mod variant {
             // For simplicity we filter all pseudo legal moves.
             moves.retain(|m| {
                 let mut after = self.clone();
-                after.play_unchecked(m);
+                after.play_unchecked(*m);
                 if let Some(our_king) = after.board().king_of(self.turn()) {
                     (after.board.kings() & after.board().by_color(!self.turn())).is_empty()
                         || after
@@ -1498,7 +1498,7 @@ pub(crate) mod variant {
             }
         }
 
-        fn play_unchecked(&mut self, m: &Move) {
+        fn play_unchecked(&mut self, m: Move) {
             do_move(
                 &mut self.board,
                 &mut Bitboard(0),
@@ -1665,7 +1665,7 @@ pub(crate) mod variant {
             self.chess.into_setup(mode)
         }
 
-        fn play_unchecked(&mut self, m: &Move) {
+        fn play_unchecked(&mut self, m: Move) {
             self.chess.play_unchecked(m);
         }
 
@@ -1806,7 +1806,7 @@ pub(crate) mod variant {
             }
         }
 
-        fn play_unchecked(&mut self, m: &Move) {
+        fn play_unchecked(&mut self, m: Move) {
             let turn = self.chess.turn();
             self.chess.play_unchecked(m);
             if self.is_check() {
@@ -1852,7 +1852,7 @@ pub(crate) mod variant {
             (self.board().by_color(color) & !self.board().kings()).is_empty()
         }
 
-        fn is_irreversible(&self, m: &Move) -> bool {
+        fn is_irreversible(&self, m: Move) -> bool {
             self.chess.is_irreversible(m) || self.chess.gives_check(m)
         }
 
@@ -2033,8 +2033,8 @@ pub(crate) mod variant {
             }
         }
 
-        fn play_unchecked(&mut self, m: &Move) {
-            match *m {
+        fn play_unchecked(&mut self, m: Move) {
+            match m {
                 Move::Normal {
                     capture: Some(capture),
                     to,
@@ -2116,8 +2116,8 @@ pub(crate) mod variant {
             moves
         }
 
-        fn is_irreversible(&self, m: &Move) -> bool {
-            match *m {
+        fn is_irreversible(&self, m: Move) -> bool {
+            match m {
                 Move::Castle { .. } => true,
                 Move::Normal { role, from, to, .. } => {
                     self.chess.castles.castling_rights().contains(from)
@@ -2307,7 +2307,7 @@ pub(crate) mod variant {
             }
         }
 
-        fn play_unchecked(&mut self, m: &Move) {
+        fn play_unchecked(&mut self, m: Move) {
             do_move(
                 &mut self.board,
                 &mut Bitboard(0),
@@ -2338,14 +2338,14 @@ pub(crate) mod variant {
 
             let blockers = slider_blockers(self.board(), self.them(), king);
             if blockers.any() {
-                moves.retain(|m| is_safe(self, king, m, blockers));
+                moves.retain(|m| is_safe(self, king, *m, blockers));
             }
 
             // Do not allow giving check. This could be implemented more
             // efficiently.
             moves.retain(|m| {
                 let mut after = self.clone();
-                after.play_unchecked(m);
+                after.play_unchecked(*m);
                 !after.is_check()
             });
 
@@ -2558,7 +2558,7 @@ pub(crate) mod variant {
             }
         }
 
-        fn play_unchecked(&mut self, m: &Move) {
+        fn play_unchecked(&mut self, m: Move) {
             do_move(
                 &mut self.board,
                 &mut Bitboard(0),
@@ -2605,7 +2605,7 @@ pub(crate) mod variant {
             if let Some(king) = king {
                 let blockers = slider_blockers(self.board(), self.them(), king);
                 if blockers.any() || has_ep {
-                    moves.retain(|m| is_safe(self, king, m, blockers));
+                    moves.retain(|m| is_safe(self, king, *m, blockers));
                 }
             }
 
@@ -3629,7 +3629,7 @@ mod tests {
         let pos: Atomic = setup_fen("rnb1kbnr/pppppppp/8/4q3/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1");
 
         let pos = pos
-            .play(&Move::Normal {
+            .play(Move::Normal {
                 role: Role::Queen,
                 from: Square::E5,
                 to: Square::E2,

--- a/src/role.rs
+++ b/src/role.rs
@@ -306,7 +306,7 @@ impl<T> ByRole<T> {
 
 #[cfg(feature = "variant")]
 impl ByRole<u8> {
-    pub(crate) fn count(&self) -> usize {
+    pub(crate) fn count(self) -> usize {
         self.iter().map(|c| usize::from(*c)).sum()
     }
 }

--- a/src/san.rs
+++ b/src/san.rs
@@ -93,7 +93,7 @@ impl fmt::Display for SanError {
 impl std::error::Error for SanError {}
 
 /// A move in Standard Algebraic Notation.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Copy, Debug, PartialEq, Eq, Clone, Hash)]
 pub enum San {
     Normal {
         role: Role,
@@ -624,7 +624,7 @@ impl fmt::Display for Suffix {
 }
 
 /// A [`San`] and possible check and checkmate suffixes.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Copy, Debug, PartialEq, Eq, Clone, Hash)]
 pub struct SanPlus {
     pub san: San,
     pub suffix: Option<Suffix>,

--- a/src/san.rs
+++ b/src/san.rs
@@ -234,8 +234,8 @@ impl San {
     /// # Errors
     ///
     /// Returns [`SanError`] if there is no unique matching legal move.
-    pub fn to_move<P: Position>(&self, pos: &P) -> Result<Move, SanError> {
-        match *self {
+    pub fn to_move<P: Position>(self, pos: &P) -> Result<Move, SanError> {
+        match self {
             San::Normal {
                 role,
                 file,
@@ -370,8 +370,8 @@ impl San {
     /// # Errors
     ///
     /// Returns [`SanError`] if there is no unique matching legal move.
-    pub fn find_move<'a>(&self, moves: &'a MoveList) -> Result<&'a Move, SanError> {
-        let mut filtered = moves.iter().filter(|m| self.matches(m));
+    pub fn find_move(self, moves: &MoveList) -> Result<&Move, SanError> {
+        let mut filtered = moves.iter().filter(|m| self.matches(**m));
 
         let Some(m) = filtered.next() else {
             return Err(SanError::IllegalSan);
@@ -400,23 +400,23 @@ impl San {
     /// };
     ///
     /// let nf3 = San::from_ascii(b"Nf3")?;
-    /// assert!(nf3.matches(&m));
+    /// assert!(nf3.matches(m));
     ///
     /// let ng1f3 = San::from_ascii(b"Ng1f3")?;
-    /// assert!(ng1f3.matches(&m));
+    /// assert!(ng1f3.matches(m));
     ///
     /// // capture does not match
     /// let nxf3 = San::from_ascii(b"Nxf3")?;
-    /// assert!(!nxf3.matches(&m));
+    /// assert!(!nxf3.matches(m));
     ///
     /// // other file does not match
     /// let nef3 = San::from_ascii(b"Nef3")?;
-    /// assert!(!nef3.matches(&m));
+    /// assert!(!nef3.matches(m));
     ///
     /// # Ok::<_, shakmaty::san::ParseSanError>(())
     /// ```
-    pub fn matches(&self, m: &Move) -> bool {
-        match *self {
+    pub fn matches(self, m: Move) -> bool {
+        match self {
             San::Normal {
                 role,
                 file,
@@ -424,7 +424,7 @@ impl San {
                 capture,
                 to,
                 promotion,
-            } => match *m {
+            } => match m {
                 Move::Normal {
                     role: r,
                     from,
@@ -450,7 +450,7 @@ impl San {
                 _ => false,
             },
             San::Castle(side) => m.castling_side().is_some_and(|s| side == s),
-            San::Put { role, to } => match *m {
+            San::Put { role, to } => match m {
                 Move::Put { role: r, to: t } => r == role && to == t,
                 _ => false,
             },
@@ -514,17 +514,17 @@ impl San {
     }
 
     #[cfg(feature = "alloc")]
-    pub fn append_to_string(&self, s: &mut alloc::string::String) {
+    pub fn append_to_string(self, s: &mut alloc::string::String) {
         let _ = self.append_to(s);
     }
 
     #[cfg(feature = "alloc")]
-    pub fn append_ascii_to(&self, buf: &mut alloc::vec::Vec<u8>) {
+    pub fn append_ascii_to(self, buf: &mut alloc::vec::Vec<u8>) {
         let _ = self.append_to(buf);
     }
 
     #[cfg(feature = "std")]
-    pub fn write_ascii_to<W: std::io::Write>(&self, w: W) -> std::io::Result<()> {
+    pub fn write_ascii_to<W: std::io::Write>(self, w: W) -> std::io::Result<()> {
         self.append_to(&mut crate::util::WriteAscii(w))
     }
 }
@@ -693,17 +693,17 @@ impl SanPlus {
     }
 
     #[cfg(feature = "alloc")]
-    pub fn append_to_string(&self, s: &mut alloc::string::String) {
+    pub fn append_to_string(self, s: &mut alloc::string::String) {
         let _ = self.append_to(s);
     }
 
     #[cfg(feature = "alloc")]
-    pub fn append_ascii_to(&self, buf: &mut alloc::vec::Vec<u8>) {
+    pub fn append_ascii_to(self, buf: &mut alloc::vec::Vec<u8>) {
         let _ = self.append_to(buf);
     }
 
     #[cfg(feature = "std")]
-    pub fn write_ascii_to<W: std::io::Write>(&self, w: W) -> std::io::Result<()> {
+    pub fn write_ascii_to<W: std::io::Write>(self, w: W) -> std::io::Result<()> {
         self.append_to(&mut crate::util::WriteAscii(w))
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -57,8 +57,8 @@ pub enum Move {
 
 impl Move {
     /// Gets the role of the moved piece.
-    pub const fn role(&self) -> Role {
-        match *self {
+    pub const fn role(self) -> Role {
+        match self {
             Move::Normal { role, .. } | Move::Put { role, .. } => role,
             Move::EnPassant { .. } => Role::Pawn,
             Move::Castle { .. } => Role::King,
@@ -66,8 +66,8 @@ impl Move {
     }
 
     /// Gets the origin square or `None` for drops.
-    pub const fn from(&self) -> Option<Square> {
-        match *self {
+    pub const fn from(self) -> Option<Square> {
+        match self {
             Move::Normal { from, .. } | Move::EnPassant { from, .. } => Some(from),
             Move::Castle { king, .. } => Some(king),
             Move::Put { .. } => None,
@@ -76,16 +76,16 @@ impl Move {
 
     /// Gets the target square. For castling moves this is the corresponding
     /// rook square.
-    pub const fn to(&self) -> Square {
-        match *self {
+    pub const fn to(self) -> Square {
+        match self {
             Move::Normal { to, .. } | Move::EnPassant { to, .. } | Move::Put { to, .. } => to,
             Move::Castle { rook, .. } => rook,
         }
     }
 
     /// Gets the role of the captured piece or `None`.
-    pub const fn capture(&self) -> Option<Role> {
-        match *self {
+    pub const fn capture(self) -> Option<Role> {
+        match self {
             Move::Normal { capture, .. } => capture,
             Move::EnPassant { .. } => Some(Role::Pawn),
             _ => None,
@@ -93,9 +93,9 @@ impl Move {
     }
 
     /// Checks if the move is a capture.
-    pub const fn is_capture(&self) -> bool {
+    pub const fn is_capture(self) -> bool {
         matches!(
-            *self,
+            self,
             Move::Normal {
                 capture: Some(_),
                 ..
@@ -104,14 +104,14 @@ impl Move {
     }
 
     /// Checks if the move is en passant.
-    pub const fn is_en_passant(&self) -> bool {
-        matches!(*self, Move::EnPassant { .. })
+    pub const fn is_en_passant(self) -> bool {
+        matches!(self, Move::EnPassant { .. })
     }
 
     /// Checks if the move zeros the half-move clock.
-    pub const fn is_zeroing(&self) -> bool {
+    pub const fn is_zeroing(self) -> bool {
         matches!(
-            *self,
+            self,
             Move::Normal {
                 role: Role::Pawn,
                 ..
@@ -127,30 +127,30 @@ impl Move {
     }
 
     /// Gets the castling side.
-    pub fn castling_side(&self) -> Option<CastlingSide> {
-        match *self {
+    pub fn castling_side(self) -> Option<CastlingSide> {
+        match self {
             Move::Castle { king, rook } => Some(CastlingSide::from_king_side(king < rook)),
             _ => None,
         }
     }
 
     /// Checks if the move is a castling move.
-    pub const fn is_castle(&self) -> bool {
-        matches!(*self, Move::Castle { .. })
+    pub const fn is_castle(self) -> bool {
+        matches!(self, Move::Castle { .. })
     }
 
     /// Gets the promotion role.
-    pub const fn promotion(&self) -> Option<Role> {
-        match *self {
+    pub const fn promotion(self) -> Option<Role> {
+        match self {
             Move::Normal { promotion, .. } => promotion,
             _ => None,
         }
     }
 
     /// Checks if the move is a promotion.
-    pub const fn is_promotion(&self) -> bool {
+    pub const fn is_promotion(self) -> bool {
         matches!(
-            *self,
+            self,
             Move::Normal {
                 promotion: Some(_),
                 ..
@@ -159,8 +159,8 @@ impl Move {
     }
 
     #[must_use]
-    pub fn to_mirrored(&self) -> Move {
-        match *self {
+    pub fn to_mirrored(self) -> Move {
+        match self {
             Move::Normal {
                 role,
                 from,

--- a/src/types.rs
+++ b/src/types.rs
@@ -36,7 +36,7 @@ impl Piece {
 /// `Move` implements [`Display`] using long algebraic notation. If a position
 /// is available for context, it is more common to use [SAN](crate::san)
 /// (for human interfaces) or [UCI](crate::uci) (for text-based protocols).
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(align(4))]
 pub enum Move {
     /// A normal move, e.g., `Bd3xh7`.

--- a/src/types.rs
+++ b/src/types.rs
@@ -36,7 +36,7 @@ impl Piece {
 /// `Move` implements [`Display`] using long algebraic notation. If a position
 /// is available for context, it is more common to use [SAN](crate::san)
 /// (for human interfaces) or [UCI](crate::uci) (for text-based protocols).
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(align(4))]
 pub enum Move {
     /// A normal move, e.g., `Bd3xh7`.

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -28,7 +28,7 @@
 //! let mut pos = Chess::default();
 //! let m = uci.to_move(&pos)?;
 //!
-//! pos.play_unchecked(&m);
+//! pos.play_unchecked(m);
 //! assert_eq!(pos.board().piece_at(Square::F3), Some(White.knight()));
 //!
 //! # #[derive(Debug)] struct CommonError;
@@ -374,7 +374,7 @@ impl UciMove {
             UciMove::Null => return Err(IllegalUciMoveError),
         };
 
-        if pos.is_legal(&candidate) {
+        if pos.is_legal(candidate) {
             Ok(candidate)
         } else {
             Err(IllegalUciMoveError)
@@ -401,8 +401,8 @@ impl UciMove {
         }
     }
 
-    fn append_to<W: AppendAscii>(&self, f: &mut W) -> Result<(), W::Error> {
-        match *self {
+    fn append_to<W: AppendAscii>(self, f: &mut W) -> Result<(), W::Error> {
+        match self {
             UciMove::Normal {
                 from,
                 to,
@@ -465,25 +465,25 @@ mod tests {
             .expect("e4")
             .to_move(&pos)
             .expect("legal");
-        pos.play_unchecked(&e4);
+        pos.play_unchecked(e4);
         let nc6 = "b8c6"
             .parse::<UciMove>()
             .expect("Nc6")
             .to_move(&pos)
             .expect("legal");
-        pos.play_unchecked(&nc6);
+        pos.play_unchecked(nc6);
         let e5 = "e4e5"
             .parse::<UciMove>()
             .expect("e5")
             .to_move(&pos)
             .expect("legal");
-        pos.play_unchecked(&e5);
+        pos.play_unchecked(e5);
         let d5 = "d7d5"
             .parse::<UciMove>()
             .expect("d5")
             .to_move(&pos)
             .expect("legal");
-        pos.play_unchecked(&d5);
+        pos.play_unchecked(d5);
         let exd5 = "e5d6"
             .parse::<UciMove>()
             .expect("exd6")
@@ -567,7 +567,7 @@ mod tests {
                 .expect("valid uci")
                 .to_move(&pos)
                 .expect("legal");
-            pos.play_unchecked(&m);
+            pos.play_unchecked(m);
         }
         assert_eq!(
             Fen::from_position(pos, crate::EnPassantMode::Legal).to_string(),

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -503,31 +503,31 @@ mod tests {
             .expect("e4")
             .to_move(&pos)
             .expect("legal");
-        pos.play_unchecked(&e4);
+        pos.play_unchecked(e4);
         let d5 = "d7d5"
             .parse::<UciMove>()
             .expect("d5")
             .to_move(&pos)
             .expect("legal");
-        pos.play_unchecked(&d5);
+        pos.play_unchecked(d5);
         let exd5 = "e4d5"
             .parse::<UciMove>()
             .expect("exd5")
             .to_move(&pos)
             .expect("legal");
-        pos.play_unchecked(&exd5);
+        pos.play_unchecked(exd5);
         let qxd5 = "d8d5"
             .parse::<UciMove>()
             .expect("Qxd5")
             .to_move(&pos)
             .expect("legal");
-        pos.play_unchecked(&qxd5);
+        pos.play_unchecked(qxd5);
         let p_at_d7 = "P@d7"
             .parse::<UciMove>()
             .expect("P@d7+")
             .to_move(&pos)
             .expect("legal");
-        pos.play_unchecked(&p_at_d7);
+        pos.play_unchecked(p_at_d7);
         assert!(pos.is_check());
     }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -104,7 +104,7 @@ impl std::error::Error for IllegalUciMoveError {}
 pub type Uci = UciMove;
 
 /// A move as represented in the UCI protocol.
-#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum UciMove {
     /// A normal move, e.g. `e2e4` or `h2h1q`.
     Normal {

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -55,10 +55,10 @@
 //! let uci = m.to_uci(pos.castles().mode());
 //! assert_eq!(uci.to_string(), "b1c3");
 //!
-//! let uci = UciMove::from_standard(&m);
+//! let uci = UciMove::from_standard(m);
 //! assert_eq!(uci.to_string(), "b1c3");
 //!
-//! let uci = UciMove::from_chess960(&m);
+//! let uci = UciMove::from_chess960(m);
 //! assert_eq!(uci.to_string(), "b1c3");
 //! ```
 //!
@@ -245,11 +245,11 @@ impl UciMove {
     ///     rook: Square::H8,
     /// };
     ///
-    /// let uci = UciMove::from_standard(&m);
+    /// let uci = UciMove::from_standard(m);
     /// assert_eq!(uci.to_string(), "e8g8");
     /// ```
-    pub fn from_standard(m: &Move) -> UciMove {
-        match *m {
+    pub fn from_standard(m: Move) -> UciMove {
+        match m {
             Move::Castle { king, rook } => {
                 let side = CastlingSide::from_king_side(king < rook);
                 UciMove::Normal {
@@ -276,11 +276,11 @@ impl UciMove {
     ///     rook: Square::H8,
     /// };
     ///
-    /// let uci = UciMove::from_chess960(&m);
+    /// let uci = UciMove::from_chess960(m);
     /// assert_eq!(uci.to_string(), "e8h8");
     /// ```
-    pub const fn from_chess960(m: &Move) -> UciMove {
-        match *m {
+    pub const fn from_chess960(m: Move) -> UciMove {
+        match m {
             Move::Normal {
                 from,
                 to,
@@ -306,7 +306,7 @@ impl UciMove {
     }
 
     /// See [`UciMove::from_standard()`] or [`UciMove::from_chess960()`].
-    pub fn from_move(m: &Move, mode: CastlingMode) -> UciMove {
+    pub fn from_move(m: Move, mode: CastlingMode) -> UciMove {
         match mode {
             CastlingMode::Standard => UciMove::from_standard(m),
             CastlingMode::Chess960 => UciMove::from_chess960(m),
@@ -321,8 +321,8 @@ impl UciMove {
     /// Returns [`IllegalUciMoveError`] if the move is not legal.
     ///
     /// [`Move`]: super::Move
-    pub fn to_move<P: Position>(&self, pos: &P) -> Result<Move, IllegalUciMoveError> {
-        let candidate = match *self {
+    pub fn to_move<P: Position>(self, pos: &P) -> Result<Move, IllegalUciMoveError> {
+        let candidate = match self {
             UciMove::Normal {
                 from,
                 to,
@@ -382,8 +382,8 @@ impl UciMove {
     }
 
     #[must_use]
-    pub fn to_mirrored(&self) -> UciMove {
-        match *self {
+    pub fn to_mirrored(self) -> UciMove {
+        match self {
             UciMove::Normal {
                 from,
                 to,
@@ -430,24 +430,24 @@ impl UciMove {
     }
 
     #[cfg(feature = "alloc")]
-    pub fn append_to_string(&self, s: &mut alloc::string::String) {
+    pub fn append_to_string(self, s: &mut alloc::string::String) {
         let _ = self.append_to(s);
     }
 
     #[cfg(feature = "alloc")]
-    pub fn append_ascii_to(&self, buf: &mut alloc::vec::Vec<u8>) {
+    pub fn append_ascii_to(self, buf: &mut alloc::vec::Vec<u8>) {
         let _ = self.append_to(buf);
     }
 
     #[cfg(feature = "std")]
-    pub fn write_ascii_to<W: std::io::Write>(&self, w: W) -> std::io::Result<()> {
+    pub fn write_ascii_to<W: std::io::Write>(self, w: W) -> std::io::Result<()> {
         self.append_to(&mut crate::util::WriteAscii(w))
     }
 }
 
 impl Move {
     /// See [`UciMove::from_move()`].
-    pub fn to_uci(&self, mode: CastlingMode) -> UciMove {
+    pub fn to_uci(self, mode: CastlingMode) -> UciMove {
         UciMove::from_move(self, mode)
     }
 }

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -381,7 +381,7 @@ impl Position for VariantPosition {
         self.borrow().promotion_moves()
     }
 
-    fn is_irreversible(&self, m: &Move) -> bool {
+    fn is_irreversible(&self, m: Move) -> bool {
         self.borrow().is_irreversible(m)
     }
 
@@ -401,7 +401,7 @@ impl Position for VariantPosition {
         self.borrow().variant_outcome()
     }
 
-    fn play_unchecked(&mut self, m: &Move) {
+    fn play_unchecked(&mut self, m: Move) {
         self.borrow_mut().play_unchecked(m);
     }
 }
@@ -414,7 +414,7 @@ mod tests {
     fn test_variant_position_play() {
         let pos = VariantPosition::new(Variant::Chess);
         let pos = pos
-            .play(&Move::Normal {
+            .play(Move::Normal {
                 role: Role::Knight,
                 from: Square::G1,
                 to: Square::F3,

--- a/tests/zobrist.rs
+++ b/tests/zobrist.rs
@@ -32,7 +32,7 @@ fn test_zobrist_reference() {
 
         for uci in record.uci {
             let m = uci.to_move(&pos).expect("legal uci");
-            pos.play_unchecked(&m);
+            pos.play_unchecked(m);
         }
 
         assert_eq!(


### PR DESCRIPTION
I changed some types smaller or equal to a `u64` (8 bytes) to be `Copy`:
- `UciMove` - 3 bytes
- `San` - 6 bytes
- `SanPlus` - 7 bytes
- `Move` - 8 bytes

I'm not sure about the explanation in #48 as to why `Move` is not `Copy`:

> The disadvantage I had in mind is that it prevents accidentally using the same move twice.

I disagree because `play` takes a reference which can be used twice too. Let's also not forget that the API would be a lot nicer with this change.

I also updated the API with e.g. `&Move` -> `Move`, which are breaking changes.