### PR TITLE
Constify `square.rs`, `attacks.rs`, ...

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - "1.75.0" # remember to update rust-version in Cargo.toml
+          - "1.85.1" # remember to update rust-version in Cargo.toml
           - "stable"
           - "nightly"
         flags:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Niklas Fiekas <niklas.fiekas@backscattering.de>"]
 categories = ["games", "parser-implementations"]
 keywords = ["chess", "lichess"]
 edition = "2021"
-rust-version = "1.75" # remember to update test.yml
+rust-version = "1.85.1" # remember to update test.yml
 
 [features]
 default = ["std"]

--- a/src/attacks.rs
+++ b/src/attacks.rs
@@ -55,14 +55,14 @@ pub const fn king_attacks(sq: Square) -> Bitboard {
 
 /// Looks up attacks for a rook on `sq` with `occupied` squares.
 #[inline]
-pub const fn rook_attacks(sq: Square, occupied: Bitboard) -> Bitboard {
+pub fn rook_attacks(sq: Square, occupied: Bitboard) -> Bitboard {
     let m = ROOK_MAGICS[sq.usize()];
 
-    // (panic) Safety: The attack table was generated with sufficient size
+    // Safety: The attack table was generated with sufficient size
     // for all relevant occupancies (all subsets of m.mask). Omitting bounds
     // checks is worth about 2% in move generation and perft.
     let idx = (m.factor.wrapping_mul(occupied.0 & m.mask) >> (64 - 12)) as usize + m.offset;
-    Bitboard(ATTACKS[idx])
+    Bitboard(unsafe { *ATTACKS.get_unchecked(idx) })
 }
 
 /// Gets the set of potential blocking squares for a rook on `sq`.
@@ -90,14 +90,14 @@ pub const fn rook_mask(sq: Square) -> Bitboard {
 
 /// Looks up attacks for a bishop on `sq` with `occupied` squares.
 #[inline]
-pub const fn bishop_attacks(sq: Square, occupied: Bitboard) -> Bitboard {
+pub fn bishop_attacks(sq: Square, occupied: Bitboard) -> Bitboard {
     let m = BISHOP_MAGICS[sq.usize()];
 
     // (panic) Safety: The attack table was generated with sufficient size
     // for all relevant occupancies (all subsets of m.mask). Omitting bounds
     // checks is worth about 2% in move generation and perft.
     let idx = (m.factor.wrapping_mul(occupied.0 & m.mask) >> (64 - 9)) as usize + m.offset;
-    Bitboard(ATTACKS[idx])
+    Bitboard(unsafe { *ATTACKS.get_unchecked(idx) })
 }
 
 /// Gets the set of potential blocking squares for a bishop on `sq`.
@@ -126,12 +126,12 @@ pub const fn bishop_mask(sq: Square) -> Bitboard {
 
 /// Looks up attacks for a queen on `sq` with `occupied` squares.
 #[inline]
-pub const fn queen_attacks(sq: Square, occupied: Bitboard) -> Bitboard {
+pub fn queen_attacks(sq: Square, occupied: Bitboard) -> Bitboard {
     rook_attacks(sq, occupied).bitxor(bishop_attacks(sq, occupied))
 }
 
 /// Looks up attacks for `piece` on `sq` with `occupied` squares.
-pub const fn attacks(sq: Square, piece: Piece, occupied: Bitboard) -> Bitboard {
+pub fn attacks(sq: Square, piece: Piece, occupied: Bitboard) -> Bitboard {
     match piece.role {
         Role::Pawn => pawn_attacks(piece.color, sq),
         Role::Knight => knight_attacks(sq),

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -29,19 +29,19 @@ impl Bitboard {
     /// A bitboard with a single square.
     #[inline]
     pub const fn from_square(sq: Square) -> Bitboard {
-        Bitboard(1 << sq as usize)
+        Bitboard(1 << sq.usize())
     }
 
     /// Returns the bitboard containing all squares of the given rank.
     #[inline]
     pub const fn from_rank(rank: Rank) -> Bitboard {
-        Bitboard(RANKS[rank as usize])
+        Bitboard(RANKS[rank.usize()])
     }
 
     /// Returns the bitboard containing all squares of the given file.
     #[inline]
     pub const fn from_file(file: File) -> Bitboard {
-        Bitboard(FILE_A << file as usize)
+        Bitboard(FILE_A << file.usize())
     }
 
     /// Silently overflowing bitwise shift with a signed offset, `<<` for

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -968,6 +968,12 @@ where
     }
 }
 
+impl Bitboard {
+    pub(crate) const fn bitxor(self, rhs: Bitboard) -> Bitboard {
+        Bitboard(self.0 ^ rhs.0)
+    }
+}
+
 impl<T> ops::BitXor<T> for Bitboard
 where
     T: Into<Bitboard>,
@@ -976,8 +982,7 @@ where
 
     #[inline]
     fn bitxor(self, rhs: T) -> Bitboard {
-        let Bitboard(rhs) = rhs.into();
-        Bitboard(self.0 ^ rhs)
+        self.bitxor(rhs.into())
     }
 }
 

--- a/src/castling_side.rs
+++ b/src/castling_side.rs
@@ -55,11 +55,11 @@ impl CastlingSide {
         }
     }
 
-    pub fn king_to(self, color: Color) -> Square {
+    pub const fn king_to(self, color: Color) -> Square {
         Square::from_coords(self.king_to_file(), color.backrank())
     }
 
-    pub fn rook_to(self, color: Color) -> Square {
+    pub const fn rook_to(self, color: Color) -> Square {
         Square::from_coords(self.rook_to_file(), color.backrank())
     }
 
@@ -135,7 +135,7 @@ impl<T> ByCastlingSide<T> {
         }
     }
 
-    pub fn swap(&mut self) {
+    pub const fn swap(&mut self) {
         mem::swap(&mut self.king_side, &mut self.queen_side);
     }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -98,7 +98,7 @@ impl Color {
     }
 
     #[inline]
-    pub fn relative_rank(self, rank: Rank) -> Rank {
+    pub const fn relative_rank(self, rank: Rank) -> Rank {
         match self {
             Color::White => rank,
             Color::Black => rank.flip_vertical(),
@@ -251,7 +251,7 @@ impl<T> ByColor<T> {
         self.swap();
     }
 
-    pub fn swap(&mut self) {
+    pub const fn swap(&mut self) {
         mem::swap(&mut self.white, &mut self.black);
     }
 

--- a/src/magics.rs
+++ b/src/magics.rs
@@ -9,7 +9,7 @@ pub struct Magic {
 }
 
 #[rustfmt::skip]
-pub const ROOK_MAGICS: [Magic; 64] = [
+pub static ROOK_MAGICS: [Magic; 64] = [
     Magic { mask: 0x0001_0101_0101_017e, factor: 0x0028_0077_ffeb_fffe, offset: 26304 },
     Magic { mask: 0x0002_0202_0202_027c, factor: 0x2004_0102_0109_7fff, offset: 35520 },
     Magic { mask: 0x0004_0404_0404_047a, factor: 0x0010_0200_1005_3fff, offset: 38592 },
@@ -77,7 +77,7 @@ pub const ROOK_MAGICS: [Magic; 64] = [
 ];
 
 #[rustfmt::skip]
-pub const BISHOP_MAGICS: [Magic; 64] = [
+pub static BISHOP_MAGICS: [Magic; 64] = [
     Magic { mask: 0x0040_2010_0804_0200, factor: 0x007f_bfbf_bfbf_bfff, offset:  5378 },
     Magic { mask: 0x0000_4020_1008_0400, factor: 0x0000_a060_4010_07fc, offset:  4093 },
     Magic { mask: 0x0000_0040_2010_0a00, factor: 0x0001_0040_0802_0000, offset:  4314 },

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -112,12 +112,12 @@ impl Setup {
 
     /// Swap turns and discard en passant rights. This is sometimes called
     /// "playing a null move".
-    pub fn swap_turn(&mut self) {
-        self.turn = !self.turn;
+    pub const fn swap_turn(&mut self) {
+        self.turn = self.turn.other();
         self.ep_square = None;
     }
 
-    pub fn into_swapped_turn(mut self) -> Setup {
+    pub const fn into_swapped_turn(mut self) -> Setup {
         self.swap_turn();
         self
     }

--- a/src/square.rs
+++ b/src/square.rs
@@ -97,7 +97,16 @@ impl File {
 
     #[inline]
     pub const fn upper_char(self) -> char {
-        self.char().to_ascii_uppercase()
+        match self {
+            File::A => 'A',
+            File::B => 'B',
+            File::C => 'C',
+            File::D => 'D',
+            File::E => 'E',
+            File::F => 'F',
+            File::G => 'G',
+            File::H => 'H',
+        }
     }
 
     #[must_use]

--- a/src/square.rs
+++ b/src/square.rs
@@ -1,5 +1,4 @@
 use core::{
-    cmp::max,
     fmt::{self, Write as _},
     mem,
     num::TryFromIntError,
@@ -68,22 +67,37 @@ impl File {
     }
 
     #[inline]
-    pub fn from_char(ch: char) -> Option<File> {
-        if ('a'..='h').contains(&ch) {
-            Some(File::new(u32::from(ch as u8 - b'a')))
-        } else {
-            None
+    pub const fn from_char(ch: char) -> Option<File> {
+        match ch {
+            'a' => Some(File::A),
+            'b' => Some(File::B),
+            'c' => Some(File::C),
+            'd' => Some(File::D),
+            'e' => Some(File::E),
+            'f' => Some(File::F),
+            'g' => Some(File::G),
+            'h' => Some(File::H),
+            _ => None,
         }
     }
 
     #[inline]
-    pub fn char(self) -> char {
-        char::from(b'a' + u8::from(self))
+    pub const fn char(self) -> char {
+        match self {
+            File::A => 'a',
+            File::B => 'b',
+            File::C => 'c',
+            File::D => 'd',
+            File::E => 'e',
+            File::F => 'f',
+            File::G => 'g',
+            File::H => 'h',
+        }
     }
 
     #[inline]
-    pub fn upper_char(self) -> char {
-        char::from(b'A' + u8::from(self))
+    pub const fn upper_char(self) -> char {
+        self.char().to_ascii_uppercase()
     }
 
     #[must_use]
@@ -95,26 +109,26 @@ impl File {
     }
 
     #[inline]
-    pub fn distance(self, other: File) -> u32 {
-        u32::from(self).abs_diff(u32::from(other))
+    pub const fn distance(self, other: File) -> u32 {
+        self.u32().abs_diff(other.u32())
     }
 
     #[must_use]
     #[inline]
-    pub fn flip_horizontal(self) -> File {
-        File::new(7 - u32::from(self))
+    pub const fn flip_horizontal(self) -> File {
+        File::new(7 - self.u32())
     }
 
     #[must_use]
     #[inline]
-    pub fn flip_diagonal(self) -> Rank {
-        Rank::new(u32::from(self))
+    pub const fn flip_diagonal(self) -> Rank {
+        Rank::new(self.u32())
     }
 
     #[must_use]
     #[inline]
-    pub fn flip_anti_diagonal(self) -> Rank {
-        Rank::new(7 - u32::from(self))
+    pub const fn flip_anti_diagonal(self) -> Rank {
+        Rank::new(7 - self.u32())
     }
 
     /// `A`, ..., `H`.
@@ -171,7 +185,7 @@ impl Rank {
     /// Panics if the index is not in the range `0..=7`.
     #[track_caller]
     #[inline]
-    pub fn new(index: u32) -> Rank {
+    pub const fn new(index: u32) -> Rank {
         assert!(index < 8);
         unsafe { Rank::new_unchecked(index) }
     }
@@ -183,23 +197,38 @@ impl Rank {
     /// It is the callers responsibility to ensure the index is in the range
     /// `0..=7`.
     #[inline]
-    pub unsafe fn new_unchecked(index: u32) -> Rank {
+    pub const unsafe fn new_unchecked(index: u32) -> Rank {
         debug_assert!(index < 8);
         unsafe { mem::transmute(index as u8) }
     }
 
     #[inline]
-    pub fn from_char(ch: char) -> Option<Rank> {
-        if ('1'..='8').contains(&ch) {
-            Some(Rank::new(u32::from(ch as u8 - b'1')))
-        } else {
-            None
+    pub const fn from_char(ch: char) -> Option<Rank> {
+        match ch {
+            '1' => Some(Rank::First),
+            '2' => Some(Rank::Second),
+            '3' => Some(Rank::Third),
+            '4' => Some(Rank::Fourth),
+            '5' => Some(Rank::Fifth),
+            '6' => Some(Rank::Sixth),
+            '7' => Some(Rank::Seventh),
+            '8' => Some(Rank::Eighth),
+            _ => None,
         }
     }
 
     #[inline]
-    pub fn char(self) -> char {
-        char::from(b'1' + u8::from(self))
+    pub const fn char(self) -> char {
+        match self {
+            Rank::First => '1',
+            Rank::Second => '2',
+            Rank::Third => '3',
+            Rank::Fourth => '4',
+            Rank::Fifth => '5',
+            Rank::Sixth => '6',
+            Rank::Seventh => '7',
+            Rank::Eighth => '8',
+        }
     }
 
     #[must_use]
@@ -211,26 +240,26 @@ impl Rank {
     }
 
     #[inline]
-    pub fn distance(self, other: Rank) -> u32 {
-        u32::from(self).abs_diff(u32::from(other))
+    pub const fn distance(self, other: Rank) -> u32 {
+        self.u32().abs_diff(other.u32())
     }
 
     #[must_use]
     #[inline]
-    pub fn flip_vertical(self) -> Rank {
-        Rank::new(7 - u32::from(self))
+    pub const fn flip_vertical(self) -> Rank {
+        Rank::new(7 - self.u32())
     }
 
     #[must_use]
     #[inline]
-    pub fn flip_diagonal(self) -> File {
-        File::new(u32::from(self))
+    pub const fn flip_diagonal(self) -> File {
+        File::new(self.u32())
     }
 
     #[must_use]
     #[inline]
-    pub fn flip_anti_diagonal(self) -> File {
-        File::new(7 - u32::from(self))
+    pub const fn flip_anti_diagonal(self) -> File {
+        File::new(7 - self.u32())
     }
 
     /// `First`, ..., `Eighth`.
@@ -336,10 +365,10 @@ impl Square {
     /// assert_eq!(Square::from_coords(File::A, Rank::First), Square::A1);
     /// ```
     #[inline]
-    pub fn from_coords(file: File, rank: Rank) -> Square {
+    pub const fn from_coords(file: File, rank: Rank) -> Square {
         // Safety: Files and ranks are represented with 3 bits each, and all
         // 6 bit values are in the range 0..=63.
-        unsafe { Square::new_unchecked(u32::from(file) | (u32::from(rank) << 3)) }
+        unsafe { Square::new_unchecked(file.u32() | (rank.u32() << 3)) }
     }
 
     /// Parses a square name.
@@ -358,11 +387,11 @@ impl Square {
     /// # Ok::<_, shakmaty::ParseSquareError>(())
     /// ```
     #[inline]
-    pub fn from_ascii(s: &[u8]) -> Result<Square, ParseSquareError> {
+    pub const fn from_ascii(s: &[u8]) -> Result<Square, ParseSquareError> {
         if s.len() == 2 {
             match (
-                File::from_char(char::from(s[0])),
-                Rank::from_char(char::from(s[1])),
+                File::from_char(s[0] as char),
+                Rank::from_char(s[1] as char),
             ) {
                 (Some(file), Some(rank)) => Ok(Square::from_coords(file, rank)),
                 _ => Err(ParseSquareError),
@@ -383,8 +412,8 @@ impl Square {
     /// assert_eq!(Square::B2.file(), File::B);
     /// ```
     #[inline]
-    pub fn file(self) -> File {
-        File::new(u32::from(self) & 7)
+    pub const fn file(self) -> File {
+        File::new(self.u32() & 7)
     }
 
     /// Gets the rank.
@@ -398,8 +427,8 @@ impl Square {
     /// assert_eq!(Square::B2.rank(), Rank::Second);
     /// ```
     #[inline]
-    pub fn rank(self) -> Rank {
-        Rank::new(u32::from(self) >> 3)
+    pub const fn rank(self) -> Rank {
+        Rank::new(self.u32() >> 3)
     }
 
     /// Gets file and rank.
@@ -413,7 +442,7 @@ impl Square {
     /// assert_eq!(Square::H8.coords(), (File::H, Rank::Eighth));
     /// ```
     #[inline]
-    pub fn coords(self) -> (File, Rank) {
+    pub const fn coords(self) -> (File, Rank) {
         (self.file(), self.rank())
     }
 
@@ -432,7 +461,7 @@ impl Square {
     #[must_use]
     #[inline]
     pub fn offset(self, delta: i32) -> Option<Square> {
-        i32::from(self)
+        self.i32()
             .checked_add(delta)
             .and_then(|index| index.try_into().ok())
     }
@@ -446,18 +475,18 @@ impl Square {
     /// offset for `self`.
     #[must_use]
     #[inline]
-    pub unsafe fn offset_unchecked(self, delta: i32) -> Square {
+    pub const unsafe fn offset_unchecked(self, delta: i32) -> Square {
         debug_assert!(-64 < delta && delta < 64);
-        unsafe { Square::new_unchecked((i32::from(self) + delta) as u32) }
+        unsafe { Square::new_unchecked((self.i32() + delta) as u32) }
     }
 
     /// Return the bitwise XOR of the numeric square representations. For some
     /// operands this is a useful geometric transformation.
     #[must_use]
     #[inline]
-    pub fn xor(self, other: Square) -> Square {
+    pub const fn xor(self, other: Square) -> Square {
         // Safety: 6 bit value XOR 6 bit value -> 6 bit value.
-        unsafe { Square::new_unchecked(u32::from(self) ^ u32::from(other)) }
+        unsafe { Square::new_unchecked(self.u32() ^ other.u32()) }
     }
 
     /// Flip the square horizontally.
@@ -470,7 +499,7 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn flip_horizontal(self) -> Square {
+    pub const fn flip_horizontal(self) -> Square {
         self.xor(Square::H1)
     }
 
@@ -484,7 +513,7 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn flip_vertical(self) -> Square {
+    pub const fn flip_vertical(self) -> Square {
         self.xor(Square::A8)
     }
 
@@ -498,11 +527,11 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn flip_diagonal(self) -> Square {
+    pub const fn flip_diagonal(self) -> Square {
         // See https://www.chessprogramming.org/Flipping_Mirroring_and_Rotating#Diagonal.
         // Safety: We are selecting 32 - 26 = 6 bits with the shift, and all
         // 6 bits values are in the range 0..=63.
-        unsafe { Square::new_unchecked(u32::from(self).wrapping_mul(0x2080_0000) >> 26) }
+        unsafe { Square::new_unchecked(self.u32().wrapping_mul(0x2080_0000) >> 26) }
     }
 
     /// Flip at the h1-a8 diagonal.
@@ -515,7 +544,7 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn flip_anti_diagonal(self) -> Square {
+    pub const fn flip_anti_diagonal(self) -> Square {
         self.flip_diagonal().rotate_180()
     }
 
@@ -529,7 +558,7 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn rotate_90(self) -> Square {
+    pub const fn rotate_90(self) -> Square {
         self.flip_diagonal().flip_vertical()
     }
 
@@ -543,7 +572,7 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn rotate_180(self) -> Square {
+    pub const fn rotate_180(self) -> Square {
         self.xor(Square::H8)
     }
 
@@ -557,7 +586,7 @@ impl Square {
     /// ```
     #[must_use]
     #[inline]
-    pub fn rotate_270(self) -> Square {
+    pub const fn rotate_270(self) -> Square {
         self.flip_diagonal().flip_horizontal()
     }
 
@@ -570,8 +599,8 @@ impl Square {
     /// assert!(!Square::D8.is_light());
     /// ```
     #[inline]
-    pub fn is_light(self) -> bool {
-        (u32::from(self.rank()) + u32::from(self.file())) % 2 == 1
+    pub const fn is_light(self) -> bool {
+        (self.rank().u32() + self.file().u32()) % 2 == 1
     }
 
     /// Tests is the square is a dark square.
@@ -583,8 +612,8 @@ impl Square {
     /// assert!(!Square::E8.is_dark());
     /// ```
     #[inline]
-    pub fn is_dark(self) -> bool {
-        (u32::from(self.rank()) + u32::from(self.file())) % 2 == 0
+    pub const fn is_dark(self) -> bool {
+        (self.rank().u32() + self.file().u32()) % 2 == 0
     }
 
     /// The distance between the two squares, i.e. the number of king steps
@@ -595,11 +624,15 @@ impl Square {
     ///
     /// assert_eq!(Square::A2.distance(Square::B5), 3);
     /// ```
-    pub fn distance(self, other: Square) -> u32 {
-        max(
-            self.file().distance(other.file()),
-            self.rank().distance(other.rank()),
-        )
+    pub const fn distance(self, other: Square) -> u32 {
+        let file_distance = self.file().distance(other.file());
+        let rank_distance = self.rank().distance(other.rank());
+
+        if file_distance > rank_distance {
+            file_distance
+        } else {
+            rank_distance
+        }
     }
 
     pub(crate) fn append_to<W: AppendAscii>(self, f: &mut W) -> Result<(), W::Error> {

--- a/src/square.rs
+++ b/src/square.rs
@@ -389,10 +389,7 @@ impl Square {
     #[inline]
     pub const fn from_ascii(s: &[u8]) -> Result<Square, ParseSquareError> {
         if s.len() == 2 {
-            match (
-                File::from_char(s[0] as char),
-                Rank::from_char(s[1] as char),
-            ) {
+            match (File::from_char(s[0] as char), Rank::from_char(s[1] as char)) {
                 (Some(file), Some(rank)) => Ok(Square::from_coords(file, rank)),
                 _ => Err(ParseSquareError),
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,8 +24,12 @@ impl Piece {
         self.color.fold_wb(self.role.upper_char(), self.role.char())
     }
 
-    pub fn from_char(ch: char) -> Option<Piece> {
-        Role::from_char(ch).map(|role| role.of(Color::from_white(32 & ch as u8 == 0)))
+    pub const fn from_char(ch: char) -> Option<Piece> {
+        if let Some(role) = Role::from_char(ch) {
+            Some(role.of(Color::from_white(32 & ch as u8 == 0)))
+        } else {
+            None
+        }
     }
 }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -401,7 +401,7 @@ impl UciMove {
     }
 
     #[must_use]
-    pub fn to_mirrored(self) -> UciMove {
+    pub const fn to_mirrored(self) -> UciMove {
         match self {
             UciMove::Normal {
                 from,

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,7 +15,7 @@ macro_rules! from_enum_as_int_impl {
         impl $from {
             $(
             #[inline]
-            const fn $t(self) -> $t {
+            pub(crate) const fn $t(self) -> $t {
                 self as $t
             }
             )+

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,11 +11,19 @@ pub(crate) fn out_of_range_error() -> TryFromIntError {
 }
 
 macro_rules! from_enum_as_int_impl {
-    ($from:ty, $($t:ty)+) => {
+    ($from:ty, $($t:ident)+) => {
+        impl $from {
+            $(
+            #[inline]
+            const fn $t(self) -> $t {
+                self as $t
+            }
+            )+
+        }
         $(impl From<$from> for $t {
             #[inline]
             fn from(value: $from) -> $t {
-                value as $t
+                value.$t()
             }
         })+
     }

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -268,7 +268,7 @@ impl VariantPosition {
         VariantPosition::from_setup(variant, setup, mode)
     }
 
-    pub fn variant(&self) -> Variant {
+    pub const fn variant(&self) -> Variant {
         match self {
             VariantPosition::Chess(_) => Variant::Chess,
             VariantPosition::Atomic(_) => Variant::Atomic,


### PR DESCRIPTION
Makes a bunch of functions `const`. Four parts of this PR:
- `square.rs` constification. All the previously non-`const` functions were not `const` because they used `From` instead of casting. I read in a previous PR that casting is something you wanted to avoid. So, I changed the `from_enum_as_int_impl` macro to also generate a private `const` function that's identical to the generated `From` implementation. The new `From` implementation just calls that private function, but internal code can use the `const` version.
- Made `UciMove::from_ascii` `const`. I've added a doctest example of how this can be useful, but I would understand if this doesn't get included, because the code is now more verbose since you can't use `?`, `ok_or` or `uci == b"0000"` in `const` contexts.
- Made some random functions `const`. This involved just changing `pub fn` to `pub const fn`, with the exception of `Setup::swap_turn`, where I had to change `!self.turn` to `self.turn.other()`. **Edit:** `ByCastlingSide::swap, Color::swap, Setup::swap_turn` only work on Rust 1.85.1 (mutable references). I added a commit to switch to that version, but feel free to ignore those changes. *Note that there are other functions in the `addendum` commit that work just fine on 1.75!*
- Made all functions in `attacks.rs` const. This is possible due to the newer Rust version, which allows using statics in const functions + the changes in `square.rs` + a private `const fn bitxor` for `Bitboard`. I have also made the magics `static`. They used to be `const` but then got imported as `static` in `attacks.rs`? I asked on the Rust Discord (linked specifically to the code here), and they were also confused.

I've not added any new casts. In fact, I removed some in `Bitboard` functions. I mean, the function replacing the cast still uses a cast, but that's exactly how `From<File> for i32` etc. is implemented.