### PR TITLE
Stricter workflows and Clippy

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,12 @@
+name: Bench
+on: [push, pull_request]
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: sudo apt-get update && sudo apt-get install -y valgrind
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo bench --all-targets

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,28 @@
+name: Check
+on: [push, pull_request]
+
+jobs:
+  check:
+    strategy:
+      matrix:
+        toolchain:
+          - "1.85.1" # remember to update rust-version in Cargo.toml
+          - "stable"
+          - "nightly"
+        include:
+          - toolchain: "nightly"
+            flags: "-Z minimal-versions"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: Main
+        run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --all-targets ${{ matrix.flags }}
+      - run: rustup target add thumbv6m-none-eabi
+      - name: No-std
+        run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --skip std --target thumbv6m-none-eabi ${{ matrix.flags }}
+      - name: Fuzz
+        run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --manifest-path fuzz/Cargo.toml --all-targets ${{ matrix.flags }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,15 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-hack
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          targets: x86_64-unknown-none
 
-      - name: Install toolchains
-        run: |
-          rustup toolchain install ${{ matrix.toolchain }}-x86_64-unknown-linux-gnu
-          rustup toolchain install --force-non-host ${{ matrix.toolchain }}-x86_64-unknown-none
-          rustup target add x86_64-unknown-none
       - name: Main
         run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --all-targets ${{ matrix.flags }}
       - name: No-std
-        run: rustup run ${{ matrix.toolchain }}-x86_64-unknown-none cargo hack check --feature-powerset --skip std --target x86_64-unknown-none ${{ matrix.flags }}
+        run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --skip std,default --target x86_64-unknown-none ${{ matrix.flags }}
       - name: Fuzz
         run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --manifest-path fuzz/Cargo.toml --all-targets ${{ matrix.flags }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-hack
 
+      - name: Install toolchains
+        run: rustup toolchain install ${{ matrix.toolchain }}-x86_64-unknown-linux-gnu
       - name: Main
         run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --all-targets ${{ matrix.flags }}
       - run: rustup target add thumbv6m-none-eabi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,11 +20,12 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
 
       - name: Install toolchains
-        run: rustup toolchain install ${{ matrix.toolchain }}-x86_64-unknown-linux-gnu
+        run: |
+          rustup toolchain install ${{ matrix.toolchain }}-x86_64-unknown-linux-gnu
+          rustup target add x86_64-unknown-none
       - name: Main
         run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --all-targets ${{ matrix.flags }}
-      - run: rustup target add thumbv6m-none-eabi
       - name: No-std
-        run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --skip std --target thumbv6m-none-eabi ${{ matrix.flags }}
+        run: rustup run ${{ matrix.toolchain }}-x86_64-unknown-none cargo hack check --feature-powerset --skip std --target x86_64-unknown-none ${{ matrix.flags }}
       - name: Fuzz
         run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --manifest-path fuzz/Cargo.toml --all-targets ${{ matrix.flags }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install toolchains
         run: |
           rustup toolchain install ${{ matrix.toolchain }}-x86_64-unknown-linux-gnu
+          rustup toolchain install ${{ matrix.toolchain }}-x86_64-unknown-none
           rustup target add x86_64-unknown-none
       - name: Main
         run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --all-targets ${{ matrix.flags }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install toolchains
         run: |
           rustup toolchain install ${{ matrix.toolchain }}-x86_64-unknown-linux-gnu
-          rustup toolchain install ${{ matrix.toolchain }}-x86_64-unknown-none
+          rustup toolchain install --force-non-host ${{ matrix.toolchain }}-x86_64-unknown-none
           rustup target add x86_64-unknown-none
       - name: Main
         run: rustup run ${{ matrix.toolchain }} cargo hack check --feature-powerset --all-targets ${{ matrix.flags }}

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -9,5 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-hack
 
-      - name: Clippy
-        run: cargo hack clippy --feature-powerset --workspace --bins --examples --benches --tests --all-targets -- --deny warnings
+      - name: Main
+        run: cargo hack clippy --feature-powerset --all-targets -- --deny warnings
+      - name: Fuzz
+        run: cargo hack clippy --feature-powerset --manifest-path fuzz/Cargo.toml --all-targets -- --deny warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,13 @@
+name: Clippy
+on: [push, pull_request]
+
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: Clippy
+        run: cargo hack clippy --feature-powerset --workspace --bins --examples --benches --tests --all-targets -- --deny warnings

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -1,0 +1,15 @@
+name: Doc check
+on: [push, pull_request]
+
+jobs:
+  doc-check:
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: "-D warnings"
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: Doc check
+        run: cargo hack --feature-powerset doc

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,13 @@
+name: Format
+on: [push, pull_request]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Format
+        run: cargo fmt --all --check

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,7 +7,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
 
       - name: Format
-        run: cargo fmt --all --check
+        run: cargo +nightly fmt --all --check

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
 
       - name: Format
         run: cargo +nightly fmt --all --check

--- a/.github/workflows/manifest-sort.yml
+++ b/.github/workflows/manifest-sort.yml
@@ -1,0 +1,18 @@
+name: Manifest sort
+on: [push, pull_request]
+
+jobs:
+  sort:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-sort
+
+      - name: Sort
+        run: cargo sort --check
+      - name: Sort fuzz
+        run: cargo sort --check fuzz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,56 +1,16 @@
 name: Test
-
-on:
-  - push
-  - pull_request
+on: [push, pull_request]
 
 jobs:
   test:
-    strategy:
-      matrix:
-        toolchain:
-          - "1.85.1" # remember to update rust-version in Cargo.toml
-          - "stable"
-          - "nightly"
-        flags:
-          - ""
-          - "--features variant,serde"
-          - "--features nohash-hasher,variant"
-          - "--features alloc"
-          - "--features alloc,variant,serde"
-          - "--features std"
-          - "--features std,variant,serde"
-        include:
-          - toolchain: "nightly"
-            flags: "-Z minimal-versions --all-features"
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain }}
-      - run: cargo test --no-default-features ${{ matrix.flags }}
-      - run: cargo doc --no-default-features ${{ matrix.flags }}
-  bench:
-    runs-on: ubuntu-latest
-    steps:
-      - run: sudo apt-get update && sudo apt-get install -y valgrind
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo bench
-  check_fuzz:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo check --manifest-path fuzz/Cargo.toml
-  check_no_std:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          targets: thumbv6m-none-eabi
-      - run: cargo check --target thumbv6m-none-eabi --no-default-features --features variant,nohash-hasher,serde
-      - run: cargo check --target thumbv6m-none-eabi --no-default-features --features alloc,variant,nohash-hasher,serde
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: Test except doc
+        run: cargo hack --feature-powerset test --all-targets
+
+      - name: Doctest
+        run: cargo hack --feature-powerset test --doc

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Niklas Fiekas <niklas.fiekas@backscattering.de>"]
 categories = ["games", "parser-implementations"]
 keywords = ["chess", "lichess"]
 edition = "2021"
-rust-version = "1.85.1" # remember to update test.yml
+rust-version = "1.85.1" # remember to update check.yml
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,15 @@ serde = ["dep:serde"]
 [[bench]]
 name = "benches"
 harness = false
+required-features = ["alloc"]
 
 [lib]
 bench = false
 
 [dependencies]
+arrayvec = { version = "0.7", default-features = false }
 bitflags = "2.0.0"
 btoi = { version = "0.4", default-features = false }
-arrayvec = { version = "0.7", default-features = false }
 nohash-hasher = { version = "0.2", default-features = false, optional = true }
 serde = { version = "1.0.197", default-features = false, optional = true }
 

--- a/src/attacks.rs
+++ b/src/attacks.rs
@@ -55,10 +55,10 @@ pub const fn king_attacks(sq: Square) -> Bitboard {
 pub const fn rook_attacks(sq: Square, occupied: Bitboard) -> Bitboard {
     let m = ROOK_MAGICS[sq.to_usize()];
 
+    let idx = (m.factor.wrapping_mul(occupied.0 & m.mask) >> (64 - 12)) as usize + m.offset;
     // Safety: The attack table was generated with sufficient size
     // for all relevant occupancies (all subsets of m.mask). Omitting bounds
     // checks is worth about 2% in move generation and perft.
-    let idx = (m.factor.wrapping_mul(occupied.0 & m.mask) >> (64 - 12)) as usize + m.offset;
     unsafe { assert_unchecked(idx < ATTACKS.len()) };
     Bitboard(ATTACKS[idx])
 }
@@ -91,10 +91,10 @@ pub const fn rook_mask(sq: Square) -> Bitboard {
 pub const fn bishop_attacks(sq: Square, occupied: Bitboard) -> Bitboard {
     let m = BISHOP_MAGICS[sq.to_usize()];
 
+    let idx = (m.factor.wrapping_mul(occupied.0 & m.mask) >> (64 - 9)) as usize + m.offset;
     // Safety: The attack table was generated with sufficient size
     // for all relevant occupancies (all subsets of m.mask). Omitting bounds
     // checks is worth about 2% in move generation and perft.
-    let idx = (m.factor.wrapping_mul(occupied.0 & m.mask) >> (64 - 9)) as usize + m.offset;
     unsafe { assert_unchecked(idx < ATTACKS.len()) };
     Bitboard(ATTACKS[idx])
 }

--- a/src/attacks.rs
+++ b/src/attacks.rs
@@ -208,8 +208,8 @@ mod tests {
     #[test]
     fn test_rook_attacks() {
         assert_eq!(
-            rook_attacks(Square::D6, Bitboard(0x3f7f28802826f5b9)),
-            Bitboard(0x8370808000000)
+            rook_attacks(Square::D6, Bitboard(0x3f7f_2880_2826_f5b9)),
+            Bitboard(0x0008_3708_0800_0000)
         );
     }
 }

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -375,7 +375,10 @@ impl Bitboard {
     #[doc(alias = "len")]
     #[inline]
     pub const fn count(self) -> u8 {
-        #[expect(clippy::cast_possible_truncation, reason = "u64 only has 64 bits in it, count_ones returns 64 at most, 64 fits in u8")]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "u64 only has 64 bits in it, count_ones returns 64 at most, 64 fits in u8"
+        )]
         {
             self.0.count_ones() as u8
         }

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -182,7 +182,7 @@ impl Bitboard {
 
     /// Clears all squares.
     #[inline]
-    pub fn clear(&mut self) {
+    pub const fn clear(&mut self) {
         self.0 = 0;
     }
 
@@ -287,7 +287,7 @@ impl Bitboard {
     /// Removes and returns the first square, if any.
     #[must_use = "use Bitboard::discard_first() if return value is not needed"]
     #[inline]
-    pub fn pop_front(&mut self) -> Option<Square> {
+    pub const fn pop_front(&mut self) -> Option<Square> {
         let square = self.first();
         self.discard_first();
         square
@@ -305,7 +305,7 @@ impl Bitboard {
 
     /// Discards the first square.
     #[inline]
-    pub fn discard_first(&mut self) {
+    pub const fn discard_first(&mut self) {
         *self = self.without_first();
     }
 

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -363,7 +363,7 @@ impl Bitboard {
         Bitboard::from_iter(self.last())
     }
 
-    /// Returns the number of squares in `self`.
+    /// Returns the number of squares in `self`. Maximum value is 64.
     ///
     /// # Examples
     ///
@@ -374,8 +374,11 @@ impl Bitboard {
     /// ```
     #[doc(alias = "len")]
     #[inline]
-    pub const fn count(self) -> usize {
-        self.0.count_ones() as usize
+    pub const fn count(self) -> u8 {
+        #[expect(clippy::cast_possible_truncation, reason = "u64 only has 64 bits in it, count_ones returns 64 at most, 64 fits in u8")]
+        {
+            self.0.count_ones() as u8
+        }
     }
 
     /// Tests if there is more than one square in `self`.
@@ -1044,13 +1047,13 @@ impl Iterator for IntoIter {
 
     #[inline]
     fn count(self) -> usize {
-        self.0.count()
+        self.0.count().into()
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.0.count();
-        (len, Some(len))
+        (len.into(), Some(len.into()))
     }
 
     #[inline]
@@ -1062,7 +1065,7 @@ impl Iterator for IntoIter {
 impl ExactSizeIterator for IntoIter {
     #[inline]
     fn len(&self) -> usize {
-        self.0.count()
+        self.0.count().into()
     }
 }
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -306,7 +306,7 @@ impl Board {
 
     pub fn material_side(&self, color: Color) -> ByRole<u8> {
         let side = self.by_color(color);
-        self.by_role.map(|pieces| (pieces & side).count() as u8)
+        self.by_role.map(|pieces| (pieces & side).count())
     }
 
     pub fn material(&self) -> ByColor<ByRole<u8>> {
@@ -560,7 +560,7 @@ impl Iterator for IntoIter {
 impl ExactSizeIterator for IntoIter {
     #[inline]
     fn len(&self) -> usize {
-        self.inner.occupied.count()
+        self.inner.occupied.count().into()
     }
 }
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -362,11 +362,12 @@ impl Board {
     }
 
     /// Swap piece colors, making black pieces white and vice versa.
-    pub fn swap_colors(&mut self) {
+    pub const fn swap_colors(&mut self) {
         self.by_color.swap();
     }
 
-    pub fn into_swapped_colors(mut self) -> Board {
+    #[must_use]
+    pub const fn into_swapped_colors(mut self) -> Board {
         self.swap_colors();
         self
     }
@@ -378,13 +379,14 @@ impl Board {
         self.swap_colors();
     }
 
+    #[must_use]
     pub fn into_mirrored(mut self) -> Board {
         self.mirror();
         self
     }
 
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.occupied.is_empty()
     }
 
@@ -527,7 +529,7 @@ pub struct IntoIter {
 
 impl IntoIter {
     /// Returns a board with the remaining pieces.
-    pub fn into_board(self) -> Board {
+    pub const fn into_board(self) -> Board {
         self.inner
     }
 }

--- a/src/board.rs
+++ b/src/board.rs
@@ -310,7 +310,7 @@ impl Board {
         self.by_role.map(|pieces| (pieces & side).count())
     }
 
-    /// Returns the amount of pieces on the board, separated by role.
+    /// Returns the amount of pieces on the board, separated by role and color.
     pub fn material(&self) -> ByColor<ByRole<u8>> {
         ByColor::new_with(|color| self.material_side(color))
     }

--- a/src/board.rs
+++ b/src/board.rs
@@ -304,11 +304,13 @@ impl Board {
                 | (attacks::pawn_attacks(attacker.other(), sq) & self.by_role.pawn))
     }
 
+    /// Returns the amount of pieces on the board owned by this `color`, separated by role.
     pub fn material_side(&self, color: Color) -> ByRole<u8> {
         let side = self.by_color(color);
         self.by_role.map(|pieces| (pieces & side).count())
     }
-
+    
+    /// Returns the amount of pieces on the board, separated by role.
     pub fn material(&self) -> ByColor<ByRole<u8>> {
         ByColor::new_with(|color| self.material_side(color))
     }

--- a/src/board.rs
+++ b/src/board.rs
@@ -309,7 +309,7 @@ impl Board {
         let side = self.by_color(color);
         self.by_role.map(|pieces| (pieces & side).count())
     }
-    
+
     /// Returns the amount of pieces on the board, separated by role.
     pub fn material(&self) -> ByColor<ByRole<u8>> {
         ByColor::new_with(|color| self.material_side(color))

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -37,9 +37,13 @@ const fn sliding_attacks(square: i32, occupied: u64, deltas: &[i32]) -> u64 {
 
 const fn init_stepping_attacks(deltas: &[i32]) -> [u64; 64] {
     let mut table = [0; 64];
-    let mut sq = 0;
+    let mut sq: usize = 0;
     while sq < 64 {
-        table[sq] = sliding_attacks(sq as i32, !0, deltas);
+        assert!(sq <= i32::MAX as usize); // private function, only used in const
+        #[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        {
+            table[sq] = sliding_attacks(sq as i32, !0, deltas);
+        }
         sq += 1;
     }
     table
@@ -52,12 +56,16 @@ pub static PAWN_ATTACKS: ByColor<[u64; 64]> = ByColor {
     black: init_stepping_attacks(&BLACK_PAWN_DELTAS),
 };
 
-const fn init_rays() -> [[u64; 64]; 64] {
+// assert makes sure it doesn't happen
+#[expect(clippy::cast_sign_loss)]
+pub static RAYS: [[u64; 64]; 64] = const {
     let mut table = [[0; 64]; 64];
     let mut a = 0;
     while a < 64 {
         let mut b = 0;
         while b < 64 {
+            assert!(a >= 0);
+            assert!(b >= 0);
             table[a as usize][b as usize] = if a == b {
                 0
             } else if a & 7 == b & 7 {
@@ -88,14 +96,15 @@ const fn init_rays() -> [[u64; 64]; 64] {
         a += 1;
     }
     table
-}
+};
 
-pub static RAYS: [[u64; 64]; 64] = init_rays();
-
-const fn init_magics() -> [u64; 88772] {
+// assert makes sure it doesn't happen
+#[expect(clippy::cast_sign_loss)]
+pub static ATTACKS: [u64; 88772] = {
     let mut table = [0; 88772];
     let mut square = 0;
     while square < 64 {
+        assert!(square >= 0);
         let magic = &magics::BISHOP_MAGICS[square as usize];
         let range = magic.mask;
         let mut subset = 0;
@@ -110,6 +119,7 @@ const fn init_magics() -> [u64; 88772] {
             }
         }
 
+        assert!(square >= 0);
         let magic = &magics::ROOK_MAGICS[square as usize];
         let range = magic.mask;
         let mut subset = 0;
@@ -127,6 +137,4 @@ const fn init_magics() -> [u64; 88772] {
         square += 1;
     }
     table
-}
-
-pub static ATTACKS: [u64; 88772] = init_magics();
+};

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -40,7 +40,11 @@ const fn init_stepping_attacks(deltas: &[i32]) -> [u64; 64] {
     let mut sq: usize = 0;
     while sq < 64 {
         assert!(sq <= i32::MAX as usize); // private function, only used in const
-        #[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap,
+            reason = "assert makes sure it doesn't happen"
+        )]
         {
             table[sq] = sliding_attacks(sq as i32, !0, deltas);
         }
@@ -56,8 +60,7 @@ pub static PAWN_ATTACKS: ByColor<[u64; 64]> = ByColor {
     black: init_stepping_attacks(&BLACK_PAWN_DELTAS),
 };
 
-// assert makes sure it doesn't happen
-#[expect(clippy::cast_sign_loss)]
+#[expect(clippy::cast_sign_loss, reason = "assert makes sure it doesn't happen")]
 pub static RAYS: [[u64; 64]; 64] = const {
     let mut table = [[0; 64]; 64];
     let mut a = 0;
@@ -98,8 +101,7 @@ pub static RAYS: [[u64; 64]; 64] = const {
     table
 };
 
-// assert makes sure it doesn't happen
-#[expect(clippy::cast_sign_loss)]
+#[expect(clippy::cast_sign_loss, reason = "assert makes sure it doesn't happen")]
 pub static ATTACKS: [u64; 88772] = {
     let mut table = [0; 88772];
     let mut square = 0;

--- a/src/castling_side.rs
+++ b/src/castling_side.rs
@@ -129,7 +129,7 @@ impl<T> ByCastlingSide<T> {
     }
 
     #[inline]
-    pub fn get_mut(&mut self, side: CastlingSide) -> &mut T {
+    pub const fn get_mut(&mut self, side: CastlingSide) -> &mut T {
         match side {
             CastlingSide::KingSide => &mut self.king_side,
             CastlingSide::QueenSide => &mut self.queen_side,
@@ -197,7 +197,7 @@ impl<T> ByCastlingSide<T> {
     }
 
     #[inline]
-    pub fn as_mut(&mut self) -> ByCastlingSide<&mut T> {
+    pub const fn as_mut(&mut self) -> ByCastlingSide<&mut T> {
         ByCastlingSide {
             king_side: &mut self.king_side,
             queen_side: &mut self.queen_side,

--- a/src/castling_side.rs
+++ b/src/castling_side.rs
@@ -64,6 +64,7 @@ impl CastlingSide {
     }
 
     #[inline]
+    #[must_use]
     pub const fn other(self) -> CastlingSide {
         match self {
             CastlingSide::KingSide => CastlingSide::QueenSide,
@@ -220,6 +221,22 @@ impl<T> ByCastlingSide<T> {
 
     pub fn iter_mut(&mut self) -> array::IntoIter<&mut T, 2> {
         self.as_mut().into_iter()
+    }
+}
+
+impl<'a, T: 'a> IntoIterator for &'a ByCastlingSide<T> {
+    type Item = &'a T;
+    type IntoIter = array::IntoIter<&'a T, 2>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T: 'a> IntoIterator for &'a mut ByCastlingSide<T> {
+    type Item = &'a T;
+    type IntoIter = array::IntoIter<&'a T, 2>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 
 /// `White` or `Black`.
-#[allow(missing_docs)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum Color {
     Black = 0,
@@ -179,8 +178,7 @@ impl fmt::Display for ParseColorError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseColorError {}
+impl core::error::Error for ParseColorError {}
 
 impl FromStr for Color {
     type Err = ParseColorError;
@@ -247,7 +245,7 @@ impl<T> ByColor<T> {
     }
 
     #[deprecated = "Use `ByColor::swap()`"]
-    pub fn flip(&mut self) {
+    pub const fn flip(&mut self) {
         self.swap();
     }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -339,6 +339,22 @@ impl<T> ByColor<T> {
     }
 }
 
+impl<'a, T: 'a> IntoIterator for &'a ByColor<T> {
+    type Item = &'a T;
+    type IntoIter = array::IntoIter<&'a T, 2>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T: 'a> IntoIterator for &'a mut ByColor<T> {
+    type Item = &'a T;
+    type IntoIter = array::IntoIter<&'a T, 2>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 impl<T> ByColor<ByRole<T>> {
     pub const fn piece(&self, piece: Piece) -> &T {
         self.get(piece.color).get(piece.role)

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -667,7 +667,7 @@ impl Epd {
     }
 
     #[allow(clippy::missing_errors_doc)] // function with errors doc linked
-    /// See [`P::from_setup`].
+    /// See [`P::from_setup`](FromSetup::from_setup).
     pub fn into_position<P: FromSetup>(self, mode: CastlingMode) -> Result<P, PositionError<P>> {
         P::from_setup(self.into_setup(), mode)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,10 @@
 #![cfg_attr(docs_rs, feature(doc_auto_cfg))]
 #![allow(clippy::must_use_candidate, reason = "triggers too much")]
 #![allow(clippy::inline_always, reason = "assumes the authors are stupid")]
-#![allow(clippy::too_many_lines, reason = "splitting things into functions which are used once is debatable")]
+#![allow(
+    clippy::too_many_lines,
+    reason = "splitting things into functions which are used once is debatable"
+)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@
 #![forbid(unsafe_op_in_unsafe_fn)]
 #![warn(missing_debug_implementations)]
 #![cfg_attr(docs_rs, feature(doc_auto_cfg))]
+#![warn(clippy::pedantic)]
+#![allow(clippy::must_use_candidate, clippy::inline_always)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,10 +67,25 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/shakmaty/0.27.3")]
 #![forbid(unsafe_op_in_unsafe_fn)]
-#![warn(missing_debug_implementations)]
+#![warn(
+    missing_debug_implementations,
+    clippy::missing_const_for_fn,
+    clippy::pedantic,
+    clippy::allow_attributes,
+    clippy::alloc_instead_of_core,
+    clippy::std_instead_of_core,
+    clippy::std_instead_of_alloc,
+    clippy::cfg_not_test,
+    clippy::clone_on_ref_ptr,
+    clippy::string_add,
+    clippy::unnecessary_safety_comment,
+    clippy::unnecessary_safety_doc,
+    clippy::tests_outside_test_module
+)]
 #![cfg_attr(docs_rs, feature(doc_auto_cfg))]
-#![warn(clippy::pedantic)]
-#![allow(clippy::must_use_candidate, clippy::inline_always)]
+#![allow(clippy::must_use_candidate, reason = "triggers too much")]
+#![allow(clippy::inline_always, reason = "assumes the authors are stupid")]
+#![allow(clippy::too_many_lines, reason = "splitting things into functions which are used once is debatable")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/position.rs
+++ b/src/position.rs
@@ -38,7 +38,10 @@ impl Outcome {
         }
     }
 
-    #[expect(clippy::missing_errors_doc, reason = "error type has relevant documentation")]
+    #[expect(
+        clippy::missing_errors_doc,
+        reason = "error type has relevant documentation"
+    )]
     pub const fn from_ascii(bytes: &[u8]) -> Result<Outcome, ParseOutcomeError> {
         Ok(match bytes {
             b"1-0" => Outcome::Decisive { winner: White },

--- a/src/position.rs
+++ b/src/position.rs
@@ -38,7 +38,7 @@ impl Outcome {
         }
     }
 
-    #[allow(clippy::missing_errors_doc)] // documented
+    #[expect(clippy::missing_errors_doc, reason = "error type has relevant documentation")]
     pub const fn from_ascii(bytes: &[u8]) -> Result<Outcome, ParseOutcomeError> {
         Ok(match bytes {
             b"1-0" => Outcome::Decisive { winner: White },
@@ -82,8 +82,7 @@ impl fmt::Display for ParseOutcomeError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseOutcomeError {}
+impl core::error::Error for ParseOutcomeError {}
 
 impl FromStr for Outcome {
     type Err = ParseOutcomeError;
@@ -116,8 +115,7 @@ impl<P: fmt::Debug> fmt::Display for PlayError<P> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<P: fmt::Debug> std::error::Error for PlayError<P> {}
+impl<P: fmt::Debug> core::error::Error for PlayError<P> {}
 
 bitflags! {
     /// Reasons for a [`Setup`] not being a legal [`Position`].
@@ -243,7 +241,7 @@ impl<P> PositionError<P> {
         self.ignore(PositionErrorKinds::TOO_MUCH_MATERIAL)
     }
 
-    #[allow(clippy::missing_errors_doc)] // deprecated
+    #[expect(clippy::missing_errors_doc, reason = "deprecated")]
     #[deprecated = "Use `PositionErrorKinds::ignore_too_much_material()`"]
     pub fn ignore_impossible_material(self) -> Result<P, Self> {
         self.ignore(PositionErrorKinds::TOO_MUCH_MATERIAL)
@@ -261,7 +259,7 @@ impl<P> PositionError<P> {
     }
 
     /// Returns the reasons for this error.
-    pub fn kinds(&self) -> PositionErrorKinds {
+    pub const fn kinds(&self) -> PositionErrorKinds {
         self.errors
     }
 }
@@ -311,8 +309,7 @@ impl<P> fmt::Display for PositionError<P> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<P> std::error::Error for PositionError<P> {}
+impl<P> core::error::Error for PositionError<P> {}
 
 /// Validate and set up a playable [`Position`]. All provided chess variants
 /// support this.
@@ -699,7 +696,7 @@ impl Chess {
         pos.is_check()
     }
 
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn from_setup_unchecked(
         setup: Setup,
         mode: CastlingMode,
@@ -1046,6 +1043,8 @@ impl Position for Chess {
 
 #[cfg(feature = "variant")]
 pub(crate) mod variant {
+    use core::{cmp::min, ops::Not};
+
     use super::{
         attacks, do_move, evasions, gen_castling_moves, gen_en_passant, gen_non_king,
         gen_safe_king, is_safe, is_standard_material, slider_blockers, validate, Bitboard, Black,
@@ -1053,7 +1052,6 @@ pub(crate) mod variant {
         FromSetup, Hash, Hasher, Move, MoveList, NonZeroU32, Outcome, Position, PositionError,
         PositionErrorKinds, Rank, RemainingChecks, Role, Setup, Square, Stepper, White,
     };
-    use core::{cmp::min, ops::Not};
 
     enum KingTag {}
 
@@ -2555,8 +2553,7 @@ pub(crate) mod variant {
         }
 
         // Aids commentary
-        // too_many_lines: function well documented
-        #[allow(clippy::nonminimal_bool, clippy::too_many_lines)]
+        #[expect(clippy::nonminimal_bool)]
         fn has_insufficient_material(&self, color: Color) -> bool {
             #[derive(Copy, Clone)]
             enum SquareColor {
@@ -2842,7 +2839,7 @@ pub(crate) mod variant {
     }
 }
 
-#[allow(clippy::too_many_arguments)] // But typesafe
+#[expect(clippy::too_many_arguments, reason = "but typesafe")]
 fn do_move(
     board: &mut Board,
     promoted: &mut Bitboard,

--- a/src/position.rs
+++ b/src/position.rs
@@ -335,8 +335,8 @@ pub trait FromSetup: Sized {
 ///
 /// # Equality
 ///
-/// All provided variants implement [`Hash`](std::hash::Hash),
-/// [`PartialEq`](std::cmp::PartialEq), and [`Eq`](std::cmp::Eq) according
+/// All provided variants implement [`Hash`],
+/// [`PartialEq`], and [`Eq`] according
 /// to FIDE rules for repeated positions. That is, considering
 ///
 /// * piece positions
@@ -664,8 +664,8 @@ pub trait Position {
 ///
 /// # Equality
 ///
-/// [`Hash`](std::hash::Hash), [`PartialEq`](std::cmp::PartialEq),
-/// and [`Eq`](std::cmp::Eq) are implemented according to FIDE rules for
+/// [`Hash`], [`PartialEq`],
+/// and [`Eq`] are implemented according to FIDE rules for
 /// repeated positions. See [`Position`](trait.Position.html#equality).
 #[derive(Clone, Debug)]
 pub struct Chess {

--- a/src/position.rs
+++ b/src/position.rs
@@ -1921,30 +1921,30 @@ pub(crate) mod variant {
                 errors |= PositionErrorKinds::TOO_MANY_KINGS;
             }
 
-            if pockets.count() + chess.board().occupied().count() > 64 {
+            if pockets.count() + usize::from(chess.board().occupied().count()) > 64 {
                 errors |= PositionErrorKinds::VARIANT;
             }
 
             errors -= PositionErrorKinds::TOO_MUCH_MATERIAL;
 
-            if promoted.count()
-                + chess.board().pawns().count()
+            if usize::from(promoted.count())
+                + usize::from(chess.board().pawns().count())
                 + usize::from(pockets.white.pawn)
                 + usize::from(pockets.black.pawn)
                 > 16
-                || (chess.board().knights() & !promoted).count()
+                || usize::from((chess.board().knights() & !promoted).count())
                     + usize::from(pockets.white.knight)
                     + usize::from(pockets.black.knight)
                     > 4
-                || (chess.board().bishops() & !promoted).count()
+                || usize::from((chess.board().bishops() & !promoted).count())
                     + usize::from(pockets.white.bishop)
                     + usize::from(pockets.black.bishop)
                     > 4
-                || (chess.board().rooks() & !promoted).count()
+                || usize::from((chess.board().rooks() & !promoted).count())
                     + usize::from(pockets.white.rook)
                     + usize::from(pockets.black.rook)
                     > 4
-                || (chess.board().queens() & !promoted).count()
+                || usize::from((chess.board().queens() & !promoted).count())
                     + usize::from(pockets.white.queen)
                     + usize::from(pockets.black.queen)
                     > 2
@@ -2100,7 +2100,7 @@ pub(crate) mod variant {
             // In practise no material can leave the game, but this is simple
             // to implement anyway. Bishops can be captured and put onto a
             // different color complex.
-            self.board().occupied().count() + self.pockets.count() <= 3
+            usize::from(self.board().occupied().count()) + self.pockets.count() <= 3
                 && self.promoted.is_empty()
                 && self.board().pawns().is_empty()
                 && self.board().rooks_and_queens().is_empty()
@@ -2597,7 +2597,7 @@ pub(crate) mod variant {
             let horde = self.board.material_side(color);
             let horde_bishops = |square_color: SquareColor| -> u8 {
                 (Bitboard::from(square_color) & self.board.by_color(color) & self.board.bishops())
-                    .count() as u8
+                    .count()
             };
             let horde_bishop_color = if horde_bishops(SquareColor::Light) >= 1 {
                 SquareColor::Light
@@ -2616,7 +2616,7 @@ pub(crate) mod variant {
             let pieces = self.board.material_side(!color);
             let pieces_bishops = |square_color: SquareColor| -> u8 {
                 (Bitboard::from(square_color) & self.board.by_color(!color) & self.board.bishops())
-                    .count() as u8
+                    .count()
             };
             let pieces_num = pieces.count() as u8;
             let pieces_of_type_not = |piece: u8| -> u8 { pieces_num - piece };

--- a/src/position.rs
+++ b/src/position.rs
@@ -678,8 +678,8 @@ pub trait Position {
 ///
 /// # Equality
 ///
-/// [`Hash`](std::hash::Hash), [`PartialEq`](std::cmp::PartialEq),
-/// and [`Eq`](std::cmp::Eq) are implemented according to FIDE rules for
+/// [`Hash`], [`PartialEq`],
+/// and [`Eq`] are implemented according to FIDE rules for
 /// repeated positions. See [`Position`](trait.Position.html#equality).
 #[derive(Clone, Debug)]
 pub struct Chess {
@@ -2556,10 +2556,7 @@ pub(crate) mod variant {
 
         // Aids commentary
         // too_many_lines: function well documented
-        #[allow(
-            clippy::nonminimal_bool,
-            clippy::too_many_lines
-        )]
+        #[allow(clippy::nonminimal_bool, clippy::too_many_lines)]
         fn has_insufficient_material(&self, color: Color) -> bool {
             #[derive(Copy, Clone)]
             enum SquareColor {
@@ -2800,7 +2797,7 @@ pub(crate) mod variant {
                     // knight on C3, as long as there is another black piece to waste
                     // a tempo.
                     pieces_num == 1
-                }
+                };
             }
 
             true

--- a/src/position.rs
+++ b/src/position.rs
@@ -2618,7 +2618,10 @@ pub(crate) mod variant {
                 (Bitboard::from(square_color) & self.board.by_color(!color) & self.board.bishops())
                     .count()
             };
-            #[expect(clippy::cast_possible_truncation, reason = "there can only be 64 pieces, thus material summed up is at most 64")]
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "there can only be 64 pieces, thus material summed up is at most 64"
+            )]
             let pieces_num = pieces.count() as u8;
             let pieces_of_type_not = |piece: u8| -> u8 { pieces_num - piece };
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -2618,6 +2618,7 @@ pub(crate) mod variant {
                 (Bitboard::from(square_color) & self.board.by_color(!color) & self.board.bishops())
                     .count()
             };
+            #[expect(clippy::cast_possible_truncation, reason = "there can only be 64 pieces, thus material summed up is at most 64")]
             let pieces_num = pieces.count() as u8;
             let pieces_of_type_not = |piece: u8| -> u8 { pieces_num - piece };
 

--- a/src/role.rs
+++ b/src/role.rs
@@ -13,7 +13,6 @@ use crate::{color::Color, types::Piece, util::out_of_range_error};
 /// assert_eq!(u32::from(Role::Pawn), 1);
 /// assert_eq!(u32::from(Role::King), 6);
 /// ```
-#[allow(missing_docs)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub enum Role {
     Pawn = 1,

--- a/src/role.rs
+++ b/src/role.rs
@@ -190,7 +190,7 @@ impl<T> ByRole<T> {
     pub const fn get(&self, role: Role) -> &T {
         // Safety: Trivial offset into #[repr(C)] struct.
         unsafe {
-            &*(self as *const ByRole<T>)
+            &*core::ptr::from_ref(self)
                 .cast::<T>()
                 .offset(role as isize - 1)
         }
@@ -200,7 +200,7 @@ impl<T> ByRole<T> {
     pub const fn get_mut(&mut self, role: Role) -> &mut T {
         // Safety: Trivial offset into #[repr(C)] struct.
         unsafe {
-            &mut *(self as *mut ByRole<T>)
+            &mut *core::ptr::from_mut(self)
                 .cast::<T>()
                 .offset(role as isize - 1)
         }
@@ -301,6 +301,24 @@ impl<T> ByRole<T> {
 
     pub fn iter_mut(&mut self) -> array::IntoIter<&mut T, 6> {
         self.as_mut().into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a ByRole<T> {
+    type Item = &'a T;
+    type IntoIter = array::IntoIter<&'a T, 6>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut ByRole<T> {
+    type Item = &'a T;
+    type IntoIter = array::IntoIter<&'a T, 6>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 

--- a/src/san.rs
+++ b/src/san.rs
@@ -323,17 +323,21 @@ impl San {
                 for candidate in moves {
                     match *candidate {
                         Move::Normal {
-                            role: r,
-                            to: t,
-                            promotion: p,
-                            from: f,
+                            role: candidate_role,
+                            to: candidate_to,
+                            promotion: candidate_promotion,
+                            from: candidate_from,
                             ..
-                        } if from != f && role == r && to == t && promotion == p => {
+                        } if from != candidate_from
+                            && role == candidate_role
+                            && to == candidate_to
+                            && promotion == candidate_promotion =>
+                        {
                             ambiguous = true;
-                            if from.rank() == f.rank() {
+                            if from.rank() == candidate_from.rank() {
                                 ambiguous_rank = true;
                             }
-                            if from.file() == f.file() {
+                            if from.file() == candidate_from.file() {
                                 ambiguous_file = true;
                             }
                         }
@@ -523,6 +527,8 @@ impl San {
         let _ = self.append_to(buf);
     }
 
+    /// # Errors
+    /// See [`Write::write_all`](std::io::Write::write_all).
     #[cfg(feature = "std")]
     pub fn write_ascii_to<W: std::io::Write>(self, w: W) -> std::io::Result<()> {
         self.append_to(&mut crate::util::WriteAscii(w))
@@ -701,7 +707,9 @@ impl SanPlus {
     pub fn append_ascii_to(self, buf: &mut alloc::vec::Vec<u8>) {
         let _ = self.append_to(buf);
     }
-
+    
+    /// # Errors
+    /// See [`Write::write_all`](std::io::Write::write_all).
     #[cfg(feature = "std")]
     pub fn write_ascii_to<W: std::io::Write>(self, w: W) -> std::io::Result<()> {
         self.append_to(&mut crate::util::WriteAscii(w))
@@ -786,7 +794,7 @@ mod tests {
             "d1=N", "@e4#", "K@b3", "Ba5", "Bba5", "Ra1a8", "--", "O-O", "O-O-O+",
         ] {
             let result = san.parse::<SanPlus>().expect("valid san").to_string();
-            assert_eq!(*san, result, "read {} write {}", san, result);
+            assert_eq!(*san, result, "read {san} write {result}");
         }
     }
 

--- a/src/san.rs
+++ b/src/san.rs
@@ -68,8 +68,7 @@ impl fmt::Display for ParseSanError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseSanError {}
+impl core::error::Error for ParseSanError {}
 
 /// `IllegalSan` or `AmbiguousSan`.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -89,8 +88,7 @@ impl fmt::Display for SanError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SanError {}
+impl core::error::Error for SanError {}
 
 /// A move in Standard Algebraic Notation.
 #[derive(Copy, Debug, PartialEq, Eq, Clone, Hash)]

--- a/src/san.rs
+++ b/src/san.rs
@@ -707,7 +707,7 @@ impl SanPlus {
     pub fn append_ascii_to(self, buf: &mut alloc::vec::Vec<u8>) {
         let _ = self.append_to(buf);
     }
-    
+
     /// # Errors
     /// See [`Write::write_all`](std::io::Write::write_all).
     #[cfg(feature = "std")]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -9,8 +9,8 @@ use crate::{
 ///
 /// # Equality
 ///
-/// [`Hash`](std::hash::Hash), [`PartialEq`](std::cmp::PartialEq), and
-/// [`Eq`](std::cmp::Eq) are implemented in terms of structural equality.
+/// [`Hash`](core::hash::Hash), [`PartialEq`], and
+/// [`Eq`] are implemented in terms of structural equality.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Setup {
     /// Piece positions on the board.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -147,7 +147,7 @@ impl Setup {
         self
     }
 
-    #[allow(clippy::missing_errors_doc)] // linked to function
+    #[expect(clippy::missing_errors_doc, reason = "linked to function")]
     /// See [`P::from_setup`](FromSetup::from_setup).
     pub fn position<P: FromSetup>(self, mode: CastlingMode) -> Result<P, PositionError<P>> {
         P::from_setup(self, mode)
@@ -240,6 +240,10 @@ impl Castles {
         }
     }
 
+    /// # Errors
+    /// Returns the same value in both `Ok` or `Err` variants.
+    /// An error signals that the setup castling rights don't match the returned [`Castles`]'s
+    /// rights.
     pub fn from_setup(setup: &Setup, mode: CastlingMode) -> Result<Castles, Castles> {
         let mut castles = Castles::empty(mode);
         let rooks = setup.castling_rights & setup.board.rooks();
@@ -299,7 +303,7 @@ impl Castles {
         self.mask.is_empty()
     }
 
-    pub fn has(&self, color: Color, side: CastlingSide) -> bool {
+    pub const fn has(&self, color: Color, side: CastlingSide) -> bool {
         self.rook(color, side).is_some()
     }
 
@@ -422,11 +426,11 @@ impl EnPassant {
         self.0
     }
 
-    pub fn pawn_pushed_from(self) -> Square {
+    pub const fn pawn_pushed_from(self) -> Square {
         self.0.xor(Square::A4)
     }
 
-    pub fn pawn_pushed_to(self) -> Square {
+    pub const fn pawn_pushed_to(self) -> Square {
         self.0.xor(Square::A2)
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -117,6 +117,7 @@ impl Setup {
         self.ep_square = None;
     }
 
+    #[must_use]
     pub const fn into_swapped_turn(mut self) -> Setup {
         self.swap_turn();
         self
@@ -140,11 +141,14 @@ impl Setup {
         }
     }
 
+    #[must_use]
     pub fn into_mirrored(mut self) -> Setup {
         self.mirror();
         self
     }
 
+    #[allow(clippy::missing_errors_doc)] // linked to function
+    /// See [`P::from_setup`].
     pub fn position<P: FromSetup>(self, mode: CastlingMode) -> Result<P, PositionError<P>> {
         P::from_setup(self, mode)
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -148,7 +148,7 @@ impl Setup {
     }
 
     #[allow(clippy::missing_errors_doc)] // linked to function
-    /// See [`P::from_setup`].
+    /// See [`P::from_setup`](FromSetup::from_setup).
     pub fn position<P: FromSetup>(self, mode: CastlingMode) -> Result<P, PositionError<P>> {
         P::from_setup(self, mode)
     }

--- a/src/square.rs
+++ b/src/square.rs
@@ -17,6 +17,13 @@ macro_rules! try_from_int_impl {
             #[allow(unused_comparisons)]
             fn try_from(value: $t) -> Result<$type, Self::Error> {
                 if ($lower..$upper).contains(&value) {
+                    // we're checking the range
+                    // cast_lossless: we don't know the type
+                    #[allow(
+                        clippy::cast_sign_loss,
+                        clippy::cast_possible_truncation,
+                        clippy::cast_lossless
+                    )]
                     Ok(<$type>::new(value as u32))
                 } else {
                     Err(out_of_range_error())
@@ -63,6 +70,7 @@ impl File {
     #[inline]
     pub const unsafe fn new_unchecked(index: u32) -> File {
         debug_assert!(index < 8);
+        #[allow(clippy::cast_possible_truncation)] // caller responsible
         unsafe { mem::transmute(index as u8) }
     }
 
@@ -693,12 +701,15 @@ impl Square {
     }
 
     #[cfg(feature = "std")]
+    /// # Errors
+    /// See [`Write::write_all`](std::io::Write::write_all).
     pub fn write_ascii_to<W: std::io::Write>(&self, w: W) -> std::io::Result<()> {
         self.append_to(&mut crate::util::WriteAscii(w))
     }
 }
 
 mod all_squares {
+    #[allow(clippy::enum_glob_use)] // no
     use super::Square::{self, *};
     impl Square {
         /// `A1`, `B1`, ..., `G8`, `H8`.

--- a/src/square.rs
+++ b/src/square.rs
@@ -71,7 +71,9 @@ impl File {
     pub const unsafe fn new_unchecked(index: u32) -> File {
         debug_assert!(index < 8);
         #[allow(clippy::cast_possible_truncation)] // caller responsible
-        unsafe { mem::transmute(index as u8) }
+        unsafe {
+            mem::transmute(index as u8)
+        }
     }
 
     #[inline]

--- a/src/square.rs
+++ b/src/square.rs
@@ -14,15 +14,14 @@ macro_rules! try_from_int_impl {
             type Error = TryFromIntError;
 
             #[inline]
-            #[allow(unused_comparisons)]
             fn try_from(value: $t) -> Result<$type, Self::Error> {
                 if ($lower..$upper).contains(&value) {
-                    // we're checking the range
-                    // cast_lossless: we don't know the type
+                    #[allow(clippy::allow_attributes, reason = "it's a macro, warnings won't always trigger")]
                     #[allow(
                         clippy::cast_sign_loss,
                         clippy::cast_possible_truncation,
-                        clippy::cast_lossless
+                        clippy::cast_lossless,
+                        reason = "we're checking the range, cast_lossless: we don't know the type"
                     )]
                     Ok(<$type>::new(value as u32))
                 } else {
@@ -34,7 +33,6 @@ macro_rules! try_from_int_impl {
 }
 
 /// A file of the chessboard.
-#[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(u8)]
 pub enum File {
@@ -70,7 +68,7 @@ impl File {
     #[inline]
     pub const unsafe fn new_unchecked(index: u32) -> File {
         debug_assert!(index < 8);
-        #[allow(clippy::cast_possible_truncation)] // caller responsible
+        #[expect(clippy::cast_possible_truncation, reason = "caller responsible")]
         unsafe {
             mem::transmute(index as u8)
         }
@@ -194,7 +192,6 @@ from_enum_as_int_impl! { File, u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 usize isi
 try_from_int_impl! { File, 0, 8, u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 usize isize }
 
 /// A rank of the chessboard.
-#[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(u8)]
 pub enum Rank {
@@ -230,7 +227,10 @@ impl Rank {
     #[inline]
     pub const unsafe fn new_unchecked(index: u32) -> Rank {
         debug_assert!(index < 8);
-        unsafe { mem::transmute(index as u8) }
+        #[expect(clippy::cast_possible_truncation, reason = "caller responsible")]
+        unsafe {
+            mem::transmute(index as u8)
+        }
     }
 
     #[inline]
@@ -346,12 +346,10 @@ impl fmt::Display for ParseSquareError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseSquareError {}
+impl core::error::Error for ParseSquareError {}
 
 /// A square of the chessboard.
 #[rustfmt::skip]
-#[allow(missing_docs)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(u8)]
 pub enum Square {
@@ -395,7 +393,10 @@ impl Square {
     #[inline]
     pub const unsafe fn new_unchecked(index: u32) -> Square {
         debug_assert!(index < 64);
-        unsafe { mem::transmute(index as u8) }
+        #[expect(clippy::cast_possible_truncation, reason = "caller responsible")]
+        unsafe {
+            mem::transmute(index as u8)
+        }
     }
 
     /// Tries to get a square from file and rank.
@@ -711,7 +712,8 @@ impl Square {
 }
 
 mod all_squares {
-    #[allow(clippy::enum_glob_use)] // no
+    #![allow(clippy::allow_attributes, reason = "false positive occurs when #[expect] is used")]
+    #[allow(clippy::enum_glob_use, reason = "nothing else is imported, would be too many imports")]
     use super::Square::{self, *};
     impl Square {
         /// `A1`, `B1`, ..., `G8`, `H8`.

--- a/src/square.rs
+++ b/src/square.rs
@@ -712,8 +712,14 @@ impl Square {
 }
 
 mod all_squares {
-    #![allow(clippy::allow_attributes, reason = "false positive occurs when #[expect] is used")]
-    #[allow(clippy::enum_glob_use, reason = "nothing else is imported, would be too many imports")]
+    #![allow(
+        clippy::allow_attributes,
+        reason = "false positive occurs when #[expect] is used"
+    )]
+    #[allow(
+        clippy::enum_glob_use,
+        reason = "nothing else is imported, would be too many imports"
+    )]
     use super::Square::{self, *};
     impl Square {
         /// `A1`, `B1`, ..., `G8`, `H8`.

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 
 /// A piece with [`Color`] and [`Role`].
-#[allow(missing_docs)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub struct Piece {
     pub color: Color,
@@ -164,7 +163,7 @@ impl Move {
     }
 
     #[must_use]
-    pub fn to_mirrored(self) -> Move {
+    pub const fn to_mirrored(self) -> Move {
         match self {
             Move::Normal {
                 role,
@@ -378,7 +377,16 @@ macro_rules! int_from_remaining_checks_impl {
         $(impl From<RemainingChecks> for $t {
             #[inline]
             fn from(RemainingChecks(checks): RemainingChecks) -> $t {
-                checks as $t
+                #[allow(clippy::allow_attributes, reason = "macro, warnings won't always trigger")]
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    clippy::cast_possible_wrap,
+                    clippy::cast_lossless,
+                    reason = "checks is always <= 3, cast_lossless: can't know the type beforehand"
+                )]
+                {
+                    checks as $t
+                }
             }
         })+
     }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -81,8 +81,7 @@ impl fmt::Display for ParseUciMoveError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseUciMoveError {}
+impl core::error::Error for ParseUciMoveError {}
 
 /// Error when UCI move is illegal.
 #[derive(Clone, Debug)]
@@ -97,8 +96,7 @@ impl fmt::Display for IllegalUciMoveError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for IllegalUciMoveError {}
+impl core::error::Error for IllegalUciMoveError {}
 
 #[deprecated = "Use `UciMove` instead"]
 pub type Uci = UciMove;

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -451,6 +451,8 @@ impl UciMove {
     }
 
     #[cfg(feature = "std")]
+    /// # Errors
+    /// See [`Write::write_all`](std::io::Write::write_all).
     pub fn write_ascii_to<W: std::io::Write>(self, w: W) -> std::io::Result<()> {
         self.append_to(&mut crate::util::WriteAscii(w))
     }

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -53,6 +53,7 @@ impl Variant {
         }
     }
 
+    #[allow(clippy::missing_errors_doc)] // documented
     /// Selects a variant based on the name used by the `UCI_Variant` option
     /// of chess engines.
     pub fn from_uci(s: &str) -> Result<Variant, ParseVariantError> {
@@ -69,6 +70,7 @@ impl Variant {
         })
     }
 
+    #[allow(clippy::missing_errors_doc)] // documented
     /// Selects a variant based on its name or known alias.
     pub fn from_ascii(s: &[u8]) -> Result<Variant, ParseVariantError> {
         Ok(match s {
@@ -213,6 +215,7 @@ impl VariantPosition {
         }
     }
 
+    #[allow(clippy::missing_errors_doc)] // documented
     #[allow(clippy::result_large_err)] // Ok variant is also large
     pub fn from_setup(
         variant: Variant,
@@ -259,6 +262,7 @@ impl VariantPosition {
         }
     }
 
+    #[allow(clippy::missing_errors_doc)] // documented
     #[allow(clippy::result_large_err)] // Ok variant is also large
     pub fn swap_turn(self) -> Result<VariantPosition, PositionError<VariantPosition>> {
         let mode = self.castles().mode();

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -53,7 +53,7 @@ impl Variant {
         }
     }
 
-    #[allow(clippy::missing_errors_doc)] // documented
+    #[expect(clippy::missing_errors_doc, reason = "error type has relevant docs")]
     /// Selects a variant based on the name used by the `UCI_Variant` option
     /// of chess engines.
     pub fn from_uci(s: &str) -> Result<Variant, ParseVariantError> {
@@ -70,9 +70,9 @@ impl Variant {
         })
     }
 
-    #[allow(clippy::missing_errors_doc)] // documented
+    #[expect(clippy::missing_errors_doc, reason = "error type has relevant docs")]
     /// Selects a variant based on its name or known alias.
-    pub fn from_ascii(s: &[u8]) -> Result<Variant, ParseVariantError> {
+    pub const fn from_ascii(s: &[u8]) -> Result<Variant, ParseVariantError> {
         Ok(match s {
             b"chess" | b"standard" | b"chess960" | b"fromPosition" | b"Standard" | b"Chess960"
             | b"From Position" => Variant::Chess,
@@ -119,8 +119,7 @@ impl fmt::Display for ParseVariantError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseVariantError {}
+impl core::error::Error for ParseVariantError {}
 
 impl FromStr for Variant {
     type Err = ParseVariantError;
@@ -134,7 +133,6 @@ impl FromStr for Variant {
 impl nohash_hasher::IsEnabled for Variant {}
 
 /// Dynamically dispatched chess variant [`Position`].
-#[allow(missing_docs)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum VariantPosition {
     Chess(Chess),
@@ -215,8 +213,7 @@ impl VariantPosition {
         }
     }
 
-    #[allow(clippy::missing_errors_doc)] // documented
-    #[allow(clippy::result_large_err)] // Ok variant is also large
+    #[expect(clippy::missing_errors_doc, reason = "error type has relevant docs")]
     pub fn from_setup(
         variant: Variant,
         setup: Setup,
@@ -262,8 +259,7 @@ impl VariantPosition {
         }
     }
 
-    #[allow(clippy::missing_errors_doc)] // documented
-    #[allow(clippy::result_large_err)] // Ok variant is also large
+    #[expect(clippy::missing_errors_doc, reason = "error type has relevant docs")]
     pub fn swap_turn(self) -> Result<VariantPosition, PositionError<VariantPosition>> {
         let mode = self.castles().mode();
         let variant = self.variant();

--- a/src/zobrist.rs
+++ b/src/zobrist.rs
@@ -1223,7 +1223,7 @@ impl Hash for Zobrist128 {
     where
         H: Hasher,
     {
-        state.write_u128(self.0);
+        state.write_u64(self.0 as u64);
     }
 }
 impl Hash for Zobrist64 {

--- a/src/zobrist.rs
+++ b/src/zobrist.rs
@@ -139,7 +139,6 @@ macro_rules! zobrist_value_impl {
 
         impl ZobristValue for $t {
             #[inline]
-            #[allow(clippy::too_many_lines)] // can't really make it shorter
             fn zobrist_for_piece(square: Square, piece: Piece) -> $t {
                 #[allow(overflowing_literals)]
                 static PIECE_MASKS: ByColor<ByRole<[$proxy; 64]>> = ByColor {
@@ -1078,7 +1077,6 @@ macro_rules! zobrist_value_impl {
             }
 
             #[inline]
-            #[allow(clippy::too_many_lines)] // can't really make it shorter
             fn zobrist_for_pocket(color: Color, role: Role, pieces: u8) -> $t {
                 #[allow(overflowing_literals)]
                 static POCKET_MASKS: ByColor<ByRole<[$proxy; 7]>> = ByColor {
@@ -1225,7 +1223,7 @@ impl Hash for Zobrist128 {
     where
         H: Hasher,
     {
-        state.write_u64(self.0 as u64); // Truncating!
+        state.write_u128(self.0);
     }
 }
 impl Hash for Zobrist64 {

--- a/src/zobrist.rs
+++ b/src/zobrist.rs
@@ -139,6 +139,7 @@ macro_rules! zobrist_value_impl {
 
         impl ZobristValue for $t {
             #[inline]
+            #[allow(clippy::too_many_lines)] // can't really make it shorter
             fn zobrist_for_piece(square: Square, piece: Piece) -> $t {
                 #[allow(overflowing_literals)]
                 static PIECE_MASKS: ByColor<ByRole<[$proxy; 64]>> = ByColor {
@@ -1077,6 +1078,7 @@ macro_rules! zobrist_value_impl {
             }
 
             #[inline]
+            #[allow(clippy::too_many_lines)] // can't really make it shorter
             fn zobrist_for_pocket(color: Color, role: Role, pieces: u8) -> $t {
                 #[allow(overflowing_literals)]
                 static POCKET_MASKS: ByColor<ByRole<[$proxy; 7]>> = ByColor {
@@ -1387,39 +1389,39 @@ mod tests {
         let reference_values = [
             (
                 "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-                Zobrist64(0x463b96181691fc9c),
+                Zobrist64(0x463b_9618_1691_fc9c),
             ),
             (
                 "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
-                Zobrist64(0x823c9b50fd114196),
+                Zobrist64(0x823c_9b50_fd11_4196),
             ),
             (
                 "rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
-                Zobrist64(0x0756b94461c50fb0),
+                Zobrist64(0x0756_b944_61c5_0fb0),
             ),
             (
                 "rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2",
-                Zobrist64(0x662fafb965db29d4),
+                Zobrist64(0x662f_afb9_65db_29d4),
             ),
             (
                 "rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 3",
-                Zobrist64(0x22a48b5a8e47ff78),
+                Zobrist64(0x22a4_8b5a_8e47_ff78),
             ),
             (
                 "rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPPKPPP/RNBQ1BNR b kq - 1 3",
-                Zobrist64(0x652a607ca3f242c1),
+                Zobrist64(0x652a_607c_a3f2_42c1),
             ),
             (
                 "rnbq1bnr/ppp1pkpp/8/3pPp2/8/8/PPPPKPPP/RNBQ1BNR w - - 2 4",
-                Zobrist64(0x00fdd303c946bdd9),
+                Zobrist64(0x00fd_d303_c946_bdd9),
             ),
             (
                 "rnbqkbnr/p1pppppp/8/8/PpP4P/8/1P1PPPP1/RNBQKBNR b KQkq c3 0 3",
-                Zobrist64(0x3c8123ea7b067637),
+                Zobrist64(0x3c81_23ea_7b06_7637),
             ),
             (
                 "rnbqkbnr/p1pppppp/8/8/P6P/R1p5/1P1PPPP1/1NBQKBNR b Kkq - 1 4",
-                Zobrist64(0x5c3f9b829b279560),
+                Zobrist64(0x5c3f_9b82_9b27_9560),
             ),
         ];
 
@@ -1433,8 +1435,7 @@ mod tests {
             assert_eq!(
                 pos.zobrist_hash::<Zobrist64>(EnPassantMode::Legal),
                 expected,
-                "{}",
-                fen
+                "{fen}",
             );
         }
     }


### PR DESCRIPTION
This PR makes workflows and Clippy stricter. Most of the newly introduced checks have been fixed (more on the unfixed ones later). It also separates the previous single workflow into multiple workflows:
- Bench: runs `cargo bench --all-targets`.
- Check: `cargo check`s the main crate, the fuzz crate, and the main crate on a target without std. The toolchain matrix is preserved.
- Clippy: runs `cargo clippy` on the main crate and the fuzz crate, but denies warnings.
- Doc check: runs `cargo doc`, but denies warnings.
- Format: runs `cargo fmt --all --check`.
- Manifest sort: checks if the Cargo.toml manifests are sorted using `cargo sort`. Kinda niche, but can be useful when managing Cargo.toml merge conflicts.
- Test: tests the crate, including doctests (which were previously untested).

Additionally, workflows take advantage of [cargo-hack](https://github.com/taiki-e/cargo-hack) to test all feature combinations (the no-std check skips the `std` and `default` features), instead of doing it manually.

Next is Clippy, which I made stricter with the following lints, ordered by impact:
- pedantic: some lints of this group have been marked as allowed. There is a technically breaking change, `Bitboard::count` returns `u8` instead of `usize`. IMHO integers should almost always reflect their boundaries. This fixes some casting warnings in the internals, as the casts are no longer necessary.
- [allow_attributes](https://rust-lang.github.io/rust-clippy/master/index.html#allow_attributes): checks for usages of `#[allow]` instead of `#[expect]`. After replacing most `#[allow]`s with `#[expect]`, plenty turned out to be unnecessary. I've also added reasons why they are allowed (mostly), but didn't turn on the [allow_attributes_without_reason](https://rust-lang.github.io/rust-clippy/master/index.html#allow_attributes_without_reason) lint. Maybe in the future.
- [missing_const_for_fn](https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn): checks for functions that can be made const. Some functions have been made const. Consistent with MSRV.
- [std_instead_of_core](https://rust-lang.github.io/rust-clippy/master/index.html#std_instead_of_core): this was only triggered with `impl std::error::Error`, which is available on `core` from 1.81.0 (below the current MSRV).
- [unnecessary_safety_comment](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_safety_comment): moved two comments to be above the expression they are actually referencing.

No fixes were needed for these, but I added them because they don't seem to have a downside:
- [std_instead_of_alloc](https://rust-lang.github.io/rust-clippy/master/index.html#std_instead_of_alloc)
- [alloc_instead_of_core](https://rust-lang.github.io/rust-clippy/master/index.html#alloc_instead_of_core)
- [cfg_not_test](https://rust-lang.github.io/rust-clippy/master/index.html#cfg_not_test)
- [clone_on_ref_ptr](https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_ref_ptr)
- [string_add](https://rust-lang.github.io/rust-clippy/master/index.html#string_add)
- [unnecessary_safety_doc](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_safety_doc)
- [tests_outside_test_module](https://rust-lang.github.io/rust-clippy/master/index.html#tests_outside_test_module)

However, there were some Clippy warnings I didn't fix:
- `#[allow(overflowing_literals)]` in `zobrist.rs:143`. I don't know much about Zobrist hashing, but is this intentional? I'm guessing the numbers are randomly generated `u128`s, and overflowing is considered good enough as opposed to generating random for each type?
- The `From<Zobrist> for Zobrist` truncations. E.g. `impl From<Zobrist32> for Zobrist16` truncates the `u32` to a `u16`. `From` is supposed to be infallible, but this conversion is not *really* infallible, as it introduces collisions. The user should have to do it manually and acknowledge that they are truncating.
- `Zobrist128`'s `Hash` impl using `state.write_u64(self.0)` to be compatible with `nohash-hasher`. I don't think `Zobrist128` should break it's `Hash` impl just to be compatible. `nohash-hasher` doesn't include 128bit integers for a reason, and making `Zobrist128` compatible is just wrong.

Also, while making `Bitboard::count` return `u8`, I stumbled upon `position.rs:2622`, which lead me to clarify `Board::material` docs to say that it includes the *amount* of pieces for each role, not the *sum*, which is what I actually thought.

And finally, I clarified the docs in `Castles::from_setup` (which has a confusing API), *but I'm not sure if they're correct.*