### PR TITLE
`proptest` integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ std = ["alloc", "btoi/std", "nohash-hasher?/std"]
 variant = []
 nohash-hasher = ["dep:nohash-hasher"]
 serde = ["dep:serde"]
+proptest = ["dep:proptest-derive", "dep:proptest", "proptest?/std", "std"]
 
 [[bench]]
 name = "benches"
@@ -33,6 +34,8 @@ bitflags = "2.0.0"
 btoi = { version = "0.4", default-features = false }
 nohash-hasher = { version = "0.2", default-features = false, optional = true }
 serde = { version = "1.0.197", default-features = false, optional = true }
+proptest-derive = { version = "0.5", default-features = false, optional = true }
+proptest = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 csv = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ std = ["alloc", "btoi/std", "nohash-hasher?/std"]
 variant = []
 nohash-hasher = ["dep:nohash-hasher"]
 serde = ["dep:serde"]
-proptest = ["dep:proptest-derive", "dep:proptest", "proptest?/std", "std"]
+proptest = ["dep:proptest-derive", "proptest/alloc"]
 
 [[bench]]
 name = "benches"

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -23,6 +23,7 @@ use crate::square::{File, Rank, Square};
 /// // . 1 . . . 1 . .
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct Bitboard(pub u64);
 
 impl Bitboard {

--- a/src/castling_side.rs
+++ b/src/castling_side.rs
@@ -7,6 +7,7 @@ use crate::{
 
 /// `KingSide` (O-O) or `QueenSide` (O-O-O).
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum CastlingSide {
     KingSide,
     QueenSide,

--- a/src/color.rs
+++ b/src/color.rs
@@ -12,6 +12,7 @@ use crate::{
 /// `White` or `Black`.
 #[allow(missing_docs)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum Color {
     Black = 0,
     White = 1,
@@ -212,6 +213,7 @@ try_color_from_int_impl! { u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 usize isize }
 
 /// Container with values for each [`Color`].
 #[derive(Copy, Clone, Default, Eq, PartialEq, Debug, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct ByColor<T> {
     pub black: T,
     pub white: T,

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -137,6 +137,7 @@ fn append_epd<W: AppendAscii>(f: &mut W, setup: &Setup) -> Result<(), W::Error> 
 
 /// Errors that can occur when parsing a FEN.
 #[derive(Clone, Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum ParseFenError {
     InvalidFen,
     InvalidBoard,

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -927,7 +927,7 @@ mod tests {
         /// `promoted` [`Bitboard`] is always empty.
         #[cfg(feature = "alloc")]
         #[test]
-        fn board_fen(board in any::<Board>()) {
+        fn board_fen_to_str_from_str(board in any::<Board>()) {
             let mut buf = Vec::with_capacity(43);
             board.board_fen(Bitboard::EMPTY).append_ascii_to(&mut buf);
 

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -887,4 +887,16 @@ mod tests {
             "rRpppppp/8/8/8/8/8/PPPPPPBN/PPRQKBNR w KA - 0 1"
         );
     }
+
+    #[cfg(feature = "proptest")]
+    proptest! {
+        /// Catches overflows.
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn fen_display_doesnt_crash(fen in any::<Fen>()) {
+            use alloc::string::ToString;
+
+            let _ = fen.to_string();
+        }
+    }
 }

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -907,7 +907,27 @@ mod tests {
         /// Uses standard Chess positions.
         #[cfg(feature = "alloc")]
         #[test]
-        fn fen_to_str_from_str(fen in fen_strategy()) {
+        fn fen_to_str_from_chess(fen in fen_strategy()) {
+            let mut buf = Vec::with_capacity(60);
+            fen.append_ascii_to(&mut buf);
+
+            match Fen::from_ascii(&buf) {
+                Ok(parsed) => assert_eq!(parsed, fen),
+                Err(e) => {
+                    let s = alloc::string::String::from_utf8(buf).expect("valid UTF-8 FEN");
+
+                    panic!("{s} should be a valid FEN but could not be parsed due to: {e}")
+                }
+            }
+        }
+
+        /// Tests that the display implementation of a [`Fen`] can always be converted
+        /// back to the same [`Fen`].
+        ///
+        /// Uses standard Chess positions.
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn fen_to_str_from_str_setup(fen in any::<Fen>()) {
             let mut buf = Vec::with_capacity(60);
             fen.append_ascii_to(&mut buf);
 

--- a/src/fen.rs
+++ b/src/fen.rs
@@ -56,6 +56,9 @@ use core::{
     str::FromStr,
 };
 
+#[cfg(feature = "proptest")]
+use proptest::prelude::*;
+
 use crate::{
     util::AppendAscii, Bitboard, Board, ByColor, ByRole, CastlingMode, Color, EnPassantMode, File,
     FromSetup, Piece, Position, PositionError, Rank, RemainingChecks, Role, Setup, Square,
@@ -342,6 +345,7 @@ impl Display for BoardFen<'_> {
 
 /// A FEN like `rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1`.
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct Fen(pub Setup);
 
 impl Fen {
@@ -724,6 +728,16 @@ impl<'de> serde::Deserialize<'de> for Epd {
         }
 
         deserializer.deserialize_str(EpdVisitor)
+    }
+}
+
+#[cfg(feature = "proptest")]
+impl Arbitrary for Epd {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        Setup::arbitrary().prop_map(Epd::from_setup).boxed()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,8 @@
 //! * `nohash-hasher`: Implements
 //!   [`nohash_hasher::IsEnabled`](https://docs.rs/nohash-hasher/0.2/nohash_hasher/trait.IsEnabled.html)
 //!   for sensible types.
+//! * `proptest`: Implements [`proptest::arbitrary::Arbitrary`](https://docs.rs/proptest/1/proptest/arbitrary/trait.Arbitrary.html)
+//!   for most types.
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/shakmaty/0.27.3")]

--- a/src/position.rs
+++ b/src/position.rs
@@ -18,6 +18,7 @@ use crate::{
 
 /// Outcome of a game.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum Outcome {
     Decisive { winner: Color },
     Draw,

--- a/src/role.rs
+++ b/src/role.rs
@@ -15,6 +15,7 @@ use crate::{color::Color, types::Piece, util::out_of_range_error};
 /// ```
 #[allow(missing_docs)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum Role {
     Pawn = 1,
     Knight = 2,
@@ -161,6 +162,7 @@ try_role_from_int_impl! { u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 usize isize }
 
 /// Container with values for each [`Role`].
 #[derive(Copy, Clone, Default, Eq, PartialEq, Debug, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 #[repr(C)]
 pub struct ByRole<T> {
     pub pawn: T,

--- a/src/san.rs
+++ b/src/san.rs
@@ -92,6 +92,7 @@ impl error::Error for SanError {}
 
 /// A move in Standard Algebraic Notation.
 #[derive(Copy, Debug, PartialEq, Eq, Clone, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum San {
     Normal {
         role: Role,
@@ -578,6 +579,7 @@ impl<'de> serde::Deserialize<'de> for San {
 
 /// Check (`+`) or checkmate (`#`) suffix.
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum Suffix {
     Check,
     Checkmate,
@@ -618,6 +620,7 @@ impl fmt::Display for Suffix {
 
 /// A [`San`] and possible check and checkmate suffixes.
 #[derive(Copy, Debug, PartialEq, Eq, Clone, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct SanPlus {
     pub san: San,
     pub suffix: Option<Suffix>,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -380,24 +380,6 @@ impl Castles {
     }
 }
 
-#[cfg(feature = "proptest")]
-impl Arbitrary for Castles {
-    type Parameters = ();
-    type Strategy = BoxedStrategy<Self>;
-
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        let setup = Setup::arbitrary();
-        let mode = CastlingMode::arbitrary();
-
-        (setup, mode)
-            .prop_filter_map(
-                "only Castles with valid Setup and CastlingMode",
-                |(setup, mode)| Castles::from_setup(&setup, mode).ok(),
-            )
-            .boxed()
-    }
-}
-
 /// En passant square on the third or sixth rank.
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct EnPassant(pub Square);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,5 +1,8 @@
 use core::{convert::identity, num::NonZeroU32};
 
+#[cfg(feature = "proptest")]
+use proptest::prelude::*;
+
 use crate::{
     attacks, Bitboard, Board, ByCastlingSide, ByColor, ByRole, CastlingMode, CastlingSide, Color,
     File, FromSetup, PositionError, Rank, RemainingChecks, Square,
@@ -374,6 +377,24 @@ impl Castles {
 
     pub const fn mode(&self) -> CastlingMode {
         self.mode
+    }
+}
+
+#[cfg(feature = "proptest")]
+impl Arbitrary for Castles {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        let setup = Setup::arbitrary();
+        let mode = CastlingMode::arbitrary();
+
+        (setup, mode)
+            .prop_filter_map(
+                "only Castles with valid Setup and CastlingMode",
+                |(setup, mode)| Castles::from_setup(&setup, mode).ok(),
+            )
+            .boxed()
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -12,6 +12,7 @@ use crate::{
 /// [`Hash`](core::hash::Hash), [`PartialEq`], and
 /// [`Eq`] are implemented in terms of structural equality.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct Setup {
     /// Piece positions on the board.
     pub board: Board,

--- a/src/square.rs
+++ b/src/square.rs
@@ -30,6 +30,7 @@ macro_rules! try_from_int_impl {
 /// A file of the chessboard.
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 #[repr(u8)]
 pub enum File {
     A = 0,
@@ -187,6 +188,7 @@ try_from_int_impl! { File, 0, 8, u8 i8 u16 i16 u32 i32 u64 i64 u128 i128 usize i
 /// A rank of the chessboard.
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 #[repr(u8)]
 pub enum Rank {
     First = 0,
@@ -344,6 +346,7 @@ impl error::Error for ParseSquareError {}
 #[allow(missing_docs)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[repr(u8)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum Square {
     A1 = 0, B1, C1, D1, E1, F1, G1, H1,
     A2, B2, C2, D2, E2, F2, G2, H2,

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,11 @@ use core::{
     num,
 };
 
+#[cfg(feature = "proptest")]
+use proptest::prelude::*;
+#[cfg(feature = "proptest")]
+use proptest_derive::Arbitrary;
+
 use crate::{
     castling_side::CastlingSide,
     color::{ByColor, Color},
@@ -14,6 +19,7 @@ use crate::{
 /// A piece with [`Color`] and [`Role`].
 #[allow(missing_docs)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[cfg_attr(feature = "proptest", derive(Arbitrary))]
 pub struct Piece {
     pub color: Color,
     pub role: Role,
@@ -43,6 +49,7 @@ impl Piece {
 /// is available for context, it is more common to use [SAN](crate::san)
 /// (for human interfaces) or [UCI](crate::uci) (for text-based protocols).
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "proptest", derive(Arbitrary))]
 pub enum Move {
     /// A normal move, e.g., `Bd3xh7`.
     Normal {
@@ -237,6 +244,7 @@ impl Display for Move {
 
 /// `Standard` or `Chess960`.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[cfg_attr(feature = "proptest", derive(Arbitrary))]
 pub enum CastlingMode {
     /// Castling notation and validity requirements for standard chess.
     ///
@@ -289,6 +297,7 @@ impl CastlingMode {
 
 /// When to include the en passant square.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[cfg_attr(feature = "proptest", derive(Arbitrary))]
 pub enum EnPassantMode {
     /// Only if there is a fully legal en passant move.
     Legal,
@@ -344,6 +353,16 @@ mod tests {
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct RemainingChecks(u32);
+
+#[cfg(feature = "proptest")]
+impl Arbitrary for RemainingChecks {
+    type Parameters = ();
+    type Strategy = proptest::strategy::Map<core::ops::RangeInclusive<u32>, fn(u32) -> Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        (0u32..=3).prop_map(Self)
+    }
+}
 
 impl Default for RemainingChecks {
     fn default() -> RemainingChecks {

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -94,6 +94,7 @@ impl error::Error for IllegalUciMoveError {}
 
 /// A move as represented in the UCI protocol.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum UciMove {
     /// A normal move, e.g. `e2e4` or `h2h1q`.
     Normal {


### PR DESCRIPTION
## What it does
- Implements [`proptest::arbitrary::Arbitrary`](https://docs.rs/proptest/1/proptest/arbitrary/trait.Arbitrary.html) for most types, gated behind the `proptest` feature flag.
- Adds a new `Position::strategy` function that creates a strategy that creates `Position`s.
- Adds a new `Board::from_bitboards_maybe` function and the `InconsistentBitboardsError` struct (not sure if I got the error descriptions right). This function is equivalent to the current `Board::from_bitboards`, but it returns an error instead of panicking. `Board::from_bitboards` now unwraps this function.
- Adds three tests leveraging the additions (red fails, green doesn't):
  - 🔴 `fen_to_str_from_str_setup`: tests that the `Display` impl of a `Fen` can be converted to the same `Fen`.
  - 🟢 `fen_to_str_from_str_chess`: same as `fen_to_str_from_str_setup`, but uses `Chess` positions to ensure legality.
  - 🟢  `board_fen_to_str_from_str`: tests that the `Display` impl of a `Fen` can be converted. `promoted` `Bitboard` is always empty, because there's no implemented strategy that generates a `Board` and a `promoted` `Bitboard`.

## Implementation
I derived most types, because they don't have runtime invariants. Manually implementing `Arbitrary`:
- `RemainingChecks` maps `(0..=3)` to `Self`.
- `Epd` maps an arbitrary `Setup` to `Epd::from_setup`.
- `Board` creates `ByRole<Bitboard>`s and `ByColor<Bitboard>`s that don't intersect (their individual components don't) and their union is equal.
- `Position::strategy(self, moves: u32)` produces a strategy plays up to a given amount of random, legal moves on `self`. "Up to" because if no legal move is found, it doesn't do anything (but it doesn't short circuit).

## Reasoning
`proptest` (or `quickcheck`) is a great testing tool and a fundamental library like `shakmaty` would benefit from having it. It can be used in a variety of ways, like the tests in this PR.

## ⚠️ `fen_to_str_from_str_setup`
This is the failure:
```
1Bp~BpPNR/pNPpp~P~p~B~/ppp~b~pPNb/Br~P~n~p~n~B~Q/n~p~NNppQ~P~/bP~PP~Ppp~P~/n~PPBNp~nn~/n~Nn~b~pnpB~ b HGFCBAhgfedcb a6 1+2 1410449079 3359915485 should be a valid FEN but could not be parsed due to: invalid castling part in fen
```
Realistically no one would ever use this FEN, but the fact that the serialized version of the FEN cannot be deserialized is nevertheless an error, at least in my opinion. Perhaps `Setup` shouldn't derive `Arbitrary`, but it explicitly states that it might not be legal, which is why the fields can be public.