### PR TITLE
Add `OpenOutcome` for representing `*`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,8 @@ pub use color::{ByColor, Color, ParseColorError};
 pub use m::{Move, MoveList};
 pub use perft::perft;
 pub use position::{
-    Chess, FromSetup, Outcome, ParseOutcomeError, PlayError, Position, PositionError,
-    PositionErrorKinds,
+    Chess, FromSetup, OpenOutcome, Outcome, ParseOpenOutcomeError, ParseOutcomeError, PlayError,
+    Position, PositionError, PositionErrorKinds,
 };
 pub use role::{ByRole, Role};
 pub use setup::{Castles, Setup};


### PR DESCRIPTION
Adds `OpenOutcome`, distinct from `Outcome` by having the `Unknown` variant to represent `*`. The other variant is `Definitive(Outcome)`.

## Why?
Mostly has to do with PGNs. In `pgn_reader`, using `Option<Outcome>` in `Visitor::outcome` is confusing, because `*` is not an outcome that is really missing (which is what `Option` means). If I wanted to cover the case of truly not missing, I would have to use `Option<Option<Outcome>>`, which isn't great.

It's also not really clear in the `Visitor` docs that `Option<Outcome>` is `*`.

## Why not in `pgn_reader`?
I was originally going to make this PR there, but I think it's useful here. For one, `pgn_reader` requires `std`, but this is not specific to PGNs.

## Additional considerations
This PR makes no breaking changes. `OpenOutcome` is not used anywhere (it's only exported). However, it could completely replace `Outcome`. Every single usage of `Outcome` as a return type (it's never used in a parameter) fits the use case of `OpenOutcome`. However, I still want to keep `Outcome` in order to be able to represent a definitive outcome.

I also have a branch ready to make a PR over at `pgn_reader`, which is the same as this but specific to that crate.