### PR TITLE
Fix `test_variant_perft`

### DIFF
--- a/tests/perft.rs
+++ b/tests/perft.rs
@@ -74,7 +74,7 @@ fn test_chess960_perft() {
 }
 
 #[cfg(feature = "variant")]
-#[cfg(test)]
+#[test]
 #[cfg_attr(miri, ignore)]
 fn test_variant_perft() {
     use shakmaty::variant;


### PR DESCRIPTION
It was annotated with `#[cfg(test)]` which is probably supposed to be `#[test]`.