### PR TITLE
PGN writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,6 +772,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 name = "pgn-reader"
 version = "0.28.0"
 dependencies = [
+ "bitflags",
  "btoi",
  "criterion",
  "crossbeam",

--- a/pgn-reader/Cargo.toml
+++ b/pgn-reader/Cargo.toml
@@ -21,6 +21,7 @@ harness = false
 memchr = "2.2"
 btoi = "0.5"
 shakmaty = { version = "0.29", path = "../shakmaty" }
+bitflags = "2"
 
 [dev-dependencies]
 crossbeam = "0.8"

--- a/pgn-reader/examples/write.rs
+++ b/pgn-reader/examples/write.rs
@@ -1,6 +1,6 @@
 use std::ops::ControlFlow;
 
-use pgn_reader::{Nag, RawComment, RawTag, Visitor, Writer, writer};
+use pgn_reader::{Nag, RawComment, RawTag, Visitor, Writer, writer, writer::MovetextToken};
 use shakmaty::{Color, KnownOutcome, Outcome, san::SanPlus};
 
 fn main() {
@@ -82,7 +82,10 @@ fn main() {
     // we can't write after an outcome! only end_variation and end_game
     assert!(matches!(
         writer.comment(&mut movetext, RawComment(b"sneaky")),
-        ControlFlow::Break(Err(writer::Error::WritingAfterOutcome))
+        ControlFlow::Break(Err(writer::Error::InvalidToken {
+            token,
+            allowed
+        })) if token == MovetextToken::COMMENT && allowed == MovetextToken::END_VARIATION | MovetextToken::END_GAME
     ));
 
     writer.end_game(movetext).unwrap();

--- a/pgn-reader/examples/write.rs
+++ b/pgn-reader/examples/write.rs
@@ -1,0 +1,97 @@
+use pgn_reader::{Nag, RawComment, RawTag, Visitor, Writer};
+use shakmaty::{Color, KnownOutcome, Outcome, san::SanPlus};
+
+fn main() {
+    let mut writer = Writer::new(Vec::new());
+    // guaranteed to continue
+    let mut tags = writer.begin_tags().continue_value().unwrap();
+
+    writer
+        .tag(&mut tags, b"Event", RawTag(b"Annual Horde Championship"))
+        .continue_value()
+        .unwrap();
+    writer
+        .tag(&mut tags, b"Site", RawTag(b"Mongolian Steppe"))
+        .continue_value()
+        .unwrap();
+    writer
+        .tag(&mut tags, b"Annotator", RawTag(b"Ben Finegold"))
+        .continue_value()
+        .unwrap();
+
+    let mut movetext = writer.begin_movetext(tags).continue_value().unwrap();
+
+    // stockfish line for horde
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"h5").unwrap())
+        .continue_value()
+        .unwrap();
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"e6").unwrap())
+        .continue_value()
+        .unwrap();
+
+    // variation for black
+    let _ = writer
+        .begin_variation(&mut movetext)
+        .continue_value()
+        .unwrap();
+
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"g6").unwrap())
+        .continue_value()
+        .unwrap();
+
+    // end it
+    writer
+        .end_variation(&mut movetext)
+        .continue_value()
+        .unwrap();
+
+    // back to mainline
+    // stop using stockfish
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"f6").unwrap())
+        .continue_value()
+        .unwrap();
+
+    // now you upset ben
+    writer
+        .comment(&mut movetext, RawComment(b"never play f6!"))
+        .continue_value()
+        .unwrap();
+
+    writer
+        .nag(&mut movetext, Nag::BLUNDER) // the truth hurts
+        .continue_value()
+        .unwrap();
+
+    // forced resignation
+    writer
+        .outcome(
+            &mut movetext,
+            Outcome::Known(KnownOutcome::Decisive {
+                winner: Color::Black,
+            }),
+        )
+        .continue_value()
+        .unwrap();
+
+    writer.end_game(movetext).unwrap();
+
+    let target = r#"[Event "Annual Horde Championship"]
+[Site "Mongolian Steppe"]
+[Annotator "Ben Finegold"]
+
+1. h5 e6 ( g6 ) 2. f6 { never play f6! } $4 0-1
+
+"#;
+
+    assert_eq!(str::from_utf8(&writer.writer).unwrap(), target);
+
+    // this count resets every begin_tags
+    assert_eq!(writer.bytes_written(), target.len());
+
+    // this count does not
+    assert_eq!(writer.total_bytes_written(), target.len());
+}

--- a/pgn-reader/examples/write.rs
+++ b/pgn-reader/examples/write.rs
@@ -1,9 +1,10 @@
 use std::ops::ControlFlow;
-use pgn_reader::{writer, Nag, RawComment, RawTag, Visitor, Writer};
+
+use pgn_reader::{Nag, RawComment, RawTag, Visitor, Writer, writer};
 use shakmaty::{Color, KnownOutcome, Outcome, san::SanPlus};
 
 fn main() {
-    let mut writer = Writer::new(Vec::new());
+    let mut writer = Writer::new(Vec::new(), writer::Config::default());
     // guaranteed to continue
     let mut tags = writer.begin_tags().continue_value().unwrap();
 

--- a/pgn-reader/examples/write.rs
+++ b/pgn-reader/examples/write.rs
@@ -1,4 +1,5 @@
-use pgn_reader::{Nag, RawComment, RawTag, Visitor, Writer};
+use std::ops::ControlFlow;
+use pgn_reader::{writer, Nag, RawComment, RawTag, Visitor, Writer};
 use shakmaty::{Color, KnownOutcome, Outcome, san::SanPlus};
 
 fn main() {
@@ -77,15 +78,18 @@ fn main() {
         .continue_value()
         .unwrap();
 
+    // we can't write after an outcome! only end_variation and end_game
+    assert!(matches!(
+        writer.comment(&mut movetext, RawComment(b"sneaky")),
+        ControlFlow::Break(Err(writer::Error::WritingAfterOutcome))
+    ));
+
     writer.end_game(movetext).unwrap();
 
-    let target = r#"[Event "Annual Horde Championship"]
-[Site "Mongolian Steppe"]
-[Annotator "Ben Finegold"]
-
-1. h5 e6 ( g6 ) 2. f6 { never play f6! } $4 0-1
-
-"#;
+    let target = "[Event \"Annual Horde Championship\"]\n\
+[Site \"Mongolian Steppe\"]\n\
+[Annotator \"Ben Finegold\"]\n\n\
+1. h5 e6 ( g6 ) 2. f6 { never play f6! } $4 0-1 \n\n";
 
     assert_eq!(str::from_utf8(&writer.writer).unwrap(), target);
 

--- a/pgn-reader/src/lib.rs
+++ b/pgn-reader/src/lib.rs
@@ -160,6 +160,7 @@ pub mod nag;
 pub mod reader;
 mod tag;
 mod visitor;
+pub mod writer;
 
 pub use comment::RawComment;
 pub use nag::Nag;
@@ -167,3 +168,4 @@ pub use reader::Reader;
 pub use shakmaty::{self, KnownOutcome, Outcome, san::SanPlus};
 pub use tag::RawTag;
 pub use visitor::{Skip, Visitor};
+pub use writer::Writer;

--- a/pgn-reader/src/visitor.rs
+++ b/pgn-reader/src/visitor.rs
@@ -30,10 +30,10 @@ pub trait Visitor {
     /// `ControlFlow::Break(_)` returned from any of the other methods.
     type Output;
 
-    /// Called at the start of the game, directly before reading game tags.
+    /// Called at the start of the game, directly before game tags.
     fn begin_tags(&mut self) -> ControlFlow<Self::Output, Self::Tags>;
 
-    /// Called when parsing a game tag pair, like `[White "Deep Blue"]`.
+    /// Called when visiting a game tag pair, like `[White "Deep Blue"]`.
     fn tag(
         &mut self,
         tags: &mut Self::Tags,
@@ -46,7 +46,7 @@ pub trait Visitor {
         ControlFlow::Continue(())
     }
 
-    /// Called after reading the tags of a game, before reading the movetext.
+    /// Called after visiting the tags of a game, before visiting the movetext.
     fn begin_movetext(&mut self, tags: Self::Tags) -> ControlFlow<Self::Output, Self::Movetext>;
 
     /// Called for each move, like `Nf3+`.
@@ -109,6 +109,6 @@ pub trait Visitor {
         ControlFlow::Continue(())
     }
 
-    /// Called after parsing a game.
+    /// Called after visiting a game.
     fn end_game(&mut self, movetext: Self::Movetext) -> Self::Output;
 }

--- a/pgn-reader/src/writer.rs
+++ b/pgn-reader/src/writer.rs
@@ -1,0 +1,541 @@
+use std::{io, io::Write, num::NonZeroUsize, ops::ControlFlow};
+
+use shakmaty::{Outcome, san::SanPlus};
+
+use crate::{Nag, RawComment, RawTag, Skip, Visitor};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Config {
+    /// Whether to skip variations.
+    /// This only dictates what the [`Writer`] returns in [`Visitor::begin_variation`].
+    ///
+    /// Defaults to `false`.
+    pub skip_variations: bool,
+    /// Defaults to `1`.
+    pub starting_move_number: NonZeroUsize,
+    /// Whether to always include move numbers,
+    /// even if the parity does not match the starting move number parity.
+    ///
+    /// For example, if the starting move number is 1 (odd), a move number is even, and
+    /// this is set to `true`, that move number will be included.
+    ///
+    /// Defaults to `false`.
+    pub always_include_move_number: bool,
+    /// Whether to include a space after a move number (`"1. e4"` if `true`, `"1.e4"` otherwise).
+    ///
+    /// Defaults to `true`.
+    pub space_after_move_number: bool,
+    /// Whether to include spaces around variation parentheses (`"( "` and `") "` if `true`, `"("` and `")"` otherwise).
+    ///
+    /// Defaults to `true`.
+    pub space_around_variation: bool,
+    /// Whether to include spaces around comment braces (`"{ "` and `" } "` if `true`, `"{"` and `"}"` otherwise).
+    ///
+    /// Defaults to `true`.
+    pub space_around_comments: bool,
+}
+
+impl Config {
+    /// A space optimized [`Config`]. Not recommended as it won't make much of a difference
+    /// and might break certain parsers.
+    pub const COMPACT: Self = Self {
+        skip_variations: false,
+        starting_move_number: NonZeroUsize::new(1).unwrap(),
+        always_include_move_number: false,
+        space_after_move_number: false,
+        space_around_variation: false,
+        space_around_comments: false,
+    };
+}
+
+impl Default for Config {
+    /// Optimized for compatibility.
+    fn default() -> Self {
+        Self {
+            skip_variations: false,
+            starting_move_number: NonZeroUsize::MIN,
+            always_include_move_number: false,
+            space_after_move_number: true,
+            space_around_variation: true,
+            space_around_comments: true,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Writer<W> {
+    pub writer: W,
+    config: Config,
+    scheduled_config: Config,
+    /// Resets to `0` every [`Visitor::begin_tags`], `total_bytes_written` doesn't.
+    bytes_written: usize,
+    total_bytes_written: usize,
+    buffer: Vec<u8>,
+    /// Buffer for making an ASCII usize.
+    usize_buffer: [u8; 20],
+    /// The move number of the last move.
+    move_number: usize,
+    /// A stack of move numbers in variations parent to the current one.
+    ///
+    /// If `self.move_number` is `7` and `self.move_numbers_below` is `[4, 9]`, this means that:
+    /// - There are 3 variations.
+    /// - The current variation is at move `7`.
+    /// - The parent variation of the current variation is at move `9`.
+    /// - The root variation is at move `4`.
+    move_numbers_below: Vec<usize>,
+}
+
+impl<W> Writer<W> {
+    pub fn new(writer: W) -> Self {
+        let config = Config::default();
+
+        Self {
+            writer,
+            config,
+            scheduled_config: config,
+            bytes_written: 0,
+            total_bytes_written: 0,
+            // the longest thing this will be used for is a tag line, which is likely not going
+            // to exceed this
+            buffer: Vec::with_capacity(200),
+            usize_buffer: [0; 20],
+            move_number: config.starting_move_number.get(),
+            move_numbers_below: Vec::new(),
+        }
+    }
+
+    /// The config currently in use.
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// The config to be used next time [`Visitor::begin_tags`] is called; see also [`Self::config`].
+    ///
+    /// The reason it's like this is to prevent changing the config while visiting a game, which
+    /// could damage the output.
+    pub fn scheduled_config(&self) -> &Config {
+        &self.scheduled_config
+    }
+
+    /// See [`Self::scheduled_config`].
+    pub fn scheduled_config_mut(&mut self) -> &mut Config {
+        &mut self.scheduled_config
+    }
+
+    fn increment_bytes_written(&mut self, bytes_written: usize) {
+        self.bytes_written += bytes_written;
+        self.total_bytes_written += bytes_written;
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct TagWriter(());
+
+impl TagWriter {
+    /// Writes a tag to the specifier writer and updates the state.
+    ///
+    /// Includes a newline (`\n`) character.
+    fn write_tag(
+        &mut self,
+        name: &[u8],
+        value: RawTag<'_>,
+        writer: &mut Writer<impl Write>,
+    ) -> io::Result<()> {
+        writer.buffer.clear();
+
+        // maybe use a fixed size buffer but I'm not sure it would be much faster
+        writer.buffer.push(b'[');
+        writer.buffer.extend(name);
+        writer.buffer.extend(b" \"");
+        writer.buffer.extend(value.encode().as_ref());
+        writer.buffer.extend(b"\"]\n");
+
+        writer
+            .writer
+            .write(&writer.buffer)
+            .map(|n| writer.increment_bytes_written(n))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct MovetextWriter(());
+
+impl MovetextWriter {
+    /// Writes a SAN to the specified writer and updates the state.
+    fn write_san_plus(
+        &mut self,
+        san_plus: SanPlus,
+        writer: &mut Writer<impl Write>,
+    ) -> io::Result<()> {
+        writer.buffer.clear();
+
+        if writer.config.always_include_move_number
+            || (writer.move_number % 2 == writer.config.starting_move_number.get() % 2)
+        {
+            let mut pos = 20;
+            let mut n = writer.move_number;
+
+            while n > 0 {
+                pos -= 1;
+                writer.usize_buffer[pos] = b'0' + (n % 10) as u8;
+                n /= 10;
+            }
+
+            writer.buffer.extend(&writer.usize_buffer[pos..]);
+            writer
+                .buffer
+                .extend(if writer.config.space_after_move_number {
+                    b". ".as_slice()
+                } else {
+                    b"."
+                });
+        }
+
+        san_plus.append_ascii_to(&mut writer.buffer);
+        writer.buffer.push(b' ');
+
+        writer
+            .writer
+            .write(&writer.buffer)
+            .map(|n| writer.increment_bytes_written(n))?;
+
+        writer.move_number += 1;
+
+        Ok(())
+    }
+
+    /// Writes a NAG and updates the state.
+    fn write_nag(&mut self, nag: Nag, writer: &mut Writer<impl Write>) -> io::Result<()> {
+        writer.buffer.clear();
+
+        nag.append_ascii_to(&mut writer.buffer);
+        writer.buffer.push(b' ');
+
+        writer
+            .writer
+            .write(&writer.buffer)
+            .map(|n| writer.increment_bytes_written(n))
+    }
+
+    /// Writes a comment and updates the state.
+    fn write_comment(
+        &mut self,
+        comment: RawComment,
+        writer: &mut Writer<impl Write>,
+    ) -> io::Result<()> {
+        writer.buffer.clear();
+
+        writer
+            .buffer
+            .extend(if writer.config.space_around_comments {
+                b"{ ".as_slice()
+            } else {
+                b"{"
+            });
+        writer.buffer.extend(comment.0);
+        writer
+            .buffer
+            .extend(if writer.config.space_around_comments {
+                b" } ".as_slice()
+            } else {
+                b"}"
+            });
+
+        writer
+            .writer
+            .write(&writer.buffer)
+            .map(|n| writer.increment_bytes_written(n))
+    }
+
+    /// Writes an outcome and updates the state.
+    fn write_outcome(
+        &mut self,
+        outcome: Outcome,
+        writer: &mut Writer<impl Write>,
+    ) -> io::Result<()> {
+        writer
+            .writer
+            .write(outcome.as_str().as_bytes())
+            .map(|n| writer.increment_bytes_written(n))
+    }
+
+    /// Writes an opening parenthesis (`(`) and updates the state.
+    fn write_begin_variation(&mut self, writer: &mut Writer<impl Write>) -> io::Result<()> {
+        writer
+            .writer
+            .write(if writer.config.space_around_variation {
+                b"( ".as_slice()
+            } else {
+                b"("
+            })
+            .map(|n| writer.increment_bytes_written(n))?;
+
+        writer.move_number = writer
+            .config
+            .starting_move_number
+            .get()
+            .max(writer.move_number.saturating_sub(1));
+        writer.move_numbers_below.push(writer.move_number);
+
+        Ok(())
+    }
+
+    /// Writes a closed parenthesis (`)`) if there was a previous open parenthesis (`(`)
+    /// and updates the state.
+    ///
+    /// Returns `true` if there was a previous open parenthesis (`(`).
+    fn write_end_variation(&mut self, writer: &mut Writer<impl Write>) -> io::Result<bool> {
+        if writer.move_numbers_below.is_empty() {
+            return Ok(false);
+        }
+
+        writer
+            .writer
+            .write(if writer.config.space_around_variation {
+                b") ".as_slice()
+            } else {
+                b")"
+            })
+            .map(|n| writer.increment_bytes_written(n))?;
+
+        if let Some(move_number) = writer.move_numbers_below.pop() {
+            writer.move_number = move_number;
+        }
+
+        Ok(true)
+    }
+}
+
+impl<W> Visitor for Writer<W>
+where
+    W: Write,
+{
+    type Tags = TagWriter;
+    type Movetext = MovetextWriter;
+    /// How many bytes were written.
+    ///
+    /// # Errors
+    ///
+    /// The only errors are from [`W::write`].
+    type Output = io::Result<usize>;
+
+    /// Guaranteed to continue.
+    fn begin_tags(&mut self) -> ControlFlow<Self::Output, Self::Tags> {
+        self.config = self.scheduled_config;
+        self.bytes_written = 0;
+        self.move_number = self.config.starting_move_number.get();
+        self.move_numbers_below.clear();
+
+        ControlFlow::Continue(TagWriter(()))
+    }
+
+    fn tag(
+        &mut self,
+        tags: &mut Self::Tags,
+        name: &[u8],
+        value: RawTag<'_>,
+    ) -> ControlFlow<Self::Output> {
+        match tags.write_tag(name, value, self) {
+            Ok(()) => ControlFlow::Continue(()),
+            Err(e) => ControlFlow::Break(Err(e)),
+        }
+    }
+
+    /// Writes a newline (`\n`) if no bytes were written; that is, if no tags were written.
+    fn begin_movetext(&mut self, _: Self::Tags) -> ControlFlow<Self::Output, Self::Movetext> {
+        if self.bytes_written == 0 {
+            return ControlFlow::Continue(MovetextWriter(()));
+        }
+
+        match self.writer.write(b"\n") {
+            Ok(bytes_written) => {
+                self.increment_bytes_written(bytes_written);
+
+                ControlFlow::Continue(MovetextWriter(()))
+            }
+            Err(e) => ControlFlow::Break(Err(e)),
+        }
+    }
+
+    fn san(
+        &mut self,
+        movetext: &mut Self::Movetext,
+        san_plus: SanPlus,
+    ) -> ControlFlow<Self::Output> {
+        match movetext.write_san_plus(san_plus, self) {
+            Ok(()) => ControlFlow::Continue(()),
+            Err(e) => ControlFlow::Break(Err(e)),
+        }
+    }
+
+    fn nag(&mut self, movetext: &mut Self::Movetext, nag: Nag) -> ControlFlow<Self::Output> {
+        match movetext.write_nag(nag, self) {
+            Ok(()) => ControlFlow::Continue(()),
+            Err(e) => ControlFlow::Break(Err(e)),
+        }
+    }
+
+    fn comment(
+        &mut self,
+        movetext: &mut Self::Movetext,
+        comment: RawComment,
+    ) -> ControlFlow<Self::Output> {
+        match movetext.write_comment(comment, self) {
+            Ok(()) => ControlFlow::Continue(()),
+            Err(e) => ControlFlow::Break(Err(e)),
+        }
+    }
+
+    fn outcome(
+        &mut self,
+        movetext: &mut Self::Movetext,
+        outcome: Outcome,
+    ) -> ControlFlow<Self::Output> {
+        match movetext.write_outcome(outcome, self) {
+            Ok(()) => ControlFlow::Continue(()),
+            Err(e) => ControlFlow::Break(Err(e)),
+        }
+    }
+
+    fn begin_variation(
+        &mut self,
+        movetext: &mut Self::Movetext,
+    ) -> ControlFlow<Self::Output, Skip> {
+        if self.config.skip_variations {
+            return ControlFlow::Continue(Skip(true));
+        }
+
+        match movetext.write_begin_variation(self) {
+            Ok(()) => ControlFlow::Continue(Skip(false)),
+            Err(e) => ControlFlow::Break(Err(e)),
+        }
+    }
+
+    fn end_variation(&mut self, movetext: &mut Self::Movetext) -> ControlFlow<Self::Output> {
+        match movetext.write_end_variation(self) {
+            Ok(_) => ControlFlow::Continue(()),
+            Err(e) => ControlFlow::Break(Err(e)),
+        }
+    }
+
+    /// Closes all variations and writes two newlines (`\n`).
+    fn end_game(&mut self, mut movetext: Self::Movetext) -> Self::Output {
+        let mut unclosed_parenthesis = movetext.write_end_variation(self)?;
+
+        while unclosed_parenthesis {
+            unclosed_parenthesis = movetext.write_end_variation(self)?;
+        }
+
+        self.writer
+            .write(b"\n\n")
+            .map(|n| self.increment_bytes_written(n))?;
+
+        Ok(self.bytes_written)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tag() {
+        let mut writer = Writer::new(Vec::new());
+        let mut tags = TagWriter(());
+
+        tags.write_tag(b"Event", RawTag(b"Unit testing \"\\ \""), &mut writer)
+            .unwrap();
+        assert_eq!(writer.writer, b"[Event \"Unit testing \\\"\\ \\\"\"]\n");
+
+        writer.writer.clear();
+
+        tags.write_tag(b"", RawTag(b""), &mut writer).unwrap();
+        assert_eq!(writer.writer, b"[ \"\"]\n");
+    }
+
+    #[test]
+    fn san_plus() {
+        // this API is not available to users
+        let mut writer = Writer::new(Vec::new());
+        let mut movetext = MovetextWriter(());
+
+        movetext
+            .write_san_plus(SanPlus::from_ascii(b"e4").unwrap(), &mut writer)
+            .unwrap();
+        assert_eq!(writer.writer, b"1. e4 ");
+
+        movetext
+            .write_san_plus(SanPlus::from_ascii(b"Nd2xf3#").unwrap(), &mut writer)
+            .unwrap();
+        assert_eq!(writer.writer, b"1. e4 Nd2xf3# ");
+
+        writer.writer.clear();
+
+        let mut writer = Writer::new(Vec::new());
+        writer.config.always_include_move_number = true;
+        let mut movetext = MovetextWriter(());
+
+        movetext
+            .write_san_plus(SanPlus::from_ascii(b"e4").unwrap(), &mut writer)
+            .unwrap();
+        assert_eq!(writer.writer, b"1. e4 ");
+
+        movetext
+            .write_san_plus(SanPlus::from_ascii(b"Nd2xf3#").unwrap(), &mut writer)
+            .unwrap();
+        assert_eq!(writer.writer, b"1. e4 2. Nd2xf3# ");
+    }
+
+    #[test]
+    fn variation() {
+        let mut writer = Writer::new(Vec::new());
+        writer.scheduled_config_mut().always_include_move_number = true;
+        let tags = writer.begin_tags().continue_value().unwrap();
+        let mut movetext = writer.begin_movetext(tags).continue_value().unwrap();
+
+        writer
+            .san(&mut movetext, SanPlus::from_ascii(b"e4").unwrap())
+            .continue_value()
+            .unwrap();
+        assert_eq!(writer.writer, b"1. e4 ");
+
+        let _ = writer
+            .begin_variation(&mut movetext)
+            .continue_value()
+            .unwrap();
+        assert_eq!(writer.writer, b"1. e4 ( ");
+
+        writer
+            .san(&mut movetext, SanPlus::from_ascii(b"d4").unwrap())
+            .continue_value()
+            .unwrap();
+        assert_eq!(writer.writer, b"1. e4 ( 1. d4 ");
+
+        let _ = writer
+            .begin_variation(&mut movetext)
+            .continue_value()
+            .unwrap();
+        assert_eq!(writer.writer, b"1. e4 ( 1. d4 ( ");
+
+        let _ = writer
+            .begin_variation(&mut movetext)
+            .continue_value()
+            .unwrap();
+        assert_eq!(writer.writer, b"1. e4 ( 1. d4 ( ( ");
+
+        let _ = writer
+            .begin_variation(&mut movetext)
+            .continue_value()
+            .unwrap();
+        assert_eq!(writer.writer, b"1. e4 ( 1. d4 ( ( ( ");
+
+        writer
+            .end_variation(&mut movetext)
+            .continue_value()
+            .unwrap();
+        assert_eq!(writer.writer, b"1. e4 ( 1. d4 ( ( ( ) ");
+
+        writer.end_game(movetext).unwrap();
+        assert_eq!(writer.writer, b"1. e4 ( 1. d4 ( ( ( ) ) ) ) \n\n");
+    }
+}

--- a/pgn-reader/src/writer/config.rs
+++ b/pgn-reader/src/writer/config.rs
@@ -1,12 +1,13 @@
 use std::num::NonZeroUsize;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Config {
+pub struct Config<Skip> {
     /// Whether to skip variations.
-    /// This only dictates what the [`Writer`](super::Writer) returns in [`Visitor::begin_variation`](crate::Visitor::begin_variation).
+    /// This dictates what the [`Writer`](super::Writer) returns in [`Visitor::begin_variation`](crate::Visitor::begin_variation)
+    /// and whether it does anything.
     ///
-    /// Defaults to `false`.
-    pub skip_variations: bool,
+    /// Defaults to `|| false`.
+    pub skip_variations: Skip,
     /// Defaults to `1`.
     pub starting_move_number: NonZeroUsize,
     /// Whether to always include move numbers,
@@ -31,11 +32,11 @@ pub struct Config {
     pub space_around_comments: bool,
 }
 
-impl Config {
+impl Config<fn() -> bool> {
     /// A space optimized [`Config`]. Not recommended as it won't make much of a difference
     /// and might break certain parsers.
     pub const COMPACT: Self = Self {
-        skip_variations: false,
+        skip_variations: || false,
         starting_move_number: NonZeroUsize::new(1).unwrap(),
         always_include_move_number: false,
         space_after_move_number: false,
@@ -44,11 +45,11 @@ impl Config {
     };
 }
 
-impl Default for Config {
+impl Default for Config<fn() -> bool> {
     /// Optimized for compatibility.
     fn default() -> Self {
         Self {
-            skip_variations: false,
+            skip_variations: || false,
             starting_move_number: NonZeroUsize::MIN,
             always_include_move_number: false,
             space_after_move_number: true,

--- a/pgn-reader/src/writer/config.rs
+++ b/pgn-reader/src/writer/config.rs
@@ -10,47 +10,13 @@ pub struct Config<Skip> {
     pub skip_variations: Skip,
     /// Defaults to `1`.
     pub starting_move_number: NonZeroUsize,
-    /// Whether to always include move numbers.
-    ///
-    /// Defaults to `false`.
-    pub always_include_move_number: bool,
-    /// Whether to include a space after a move number (`"1. e4"` if `true`, `"1.e4"` otherwise).
-    ///
-    /// Defaults to `true`.
-    pub space_after_move_number: bool,
-    /// Whether to include spaces around variation parentheses (`"( "` and `") "` if `true`, `"("` and `")"` otherwise).
-    ///
-    /// Defaults to `true`.
-    pub space_around_variation: bool,
-    /// Whether to include spaces around comment braces (`"{ "` and `" } "` if `true`, `"{"` and `"}"` otherwise).
-    ///
-    /// Defaults to `true`.
-    pub space_around_comments: bool,
-}
-
-impl Config<fn() -> bool> {
-    /// A space optimized [`Config`]. Not recommended as it won't make much of a difference
-    /// and might break certain parsers.
-    pub const COMPACT: Self = Self {
-        skip_variations: || false,
-        starting_move_number: NonZeroUsize::new(1).unwrap(),
-        always_include_move_number: false,
-        space_after_move_number: false,
-        space_around_variation: false,
-        space_around_comments: false,
-    };
 }
 
 impl Default for Config<fn() -> bool> {
-    /// Optimized for compatibility.
     fn default() -> Self {
         Self {
             skip_variations: || false,
             starting_move_number: NonZeroUsize::MIN,
-            always_include_move_number: false,
-            space_after_move_number: true,
-            space_around_variation: true,
-            space_around_comments: true,
         }
     }
 }

--- a/pgn-reader/src/writer/config.rs
+++ b/pgn-reader/src/writer/config.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Config<Skip> {
     /// Whether to skip variations.
-    /// This dictates what the [`Writer`](super::Writer) returns in [`Visitor::begin_variation`](crate::Visitor::begin_variation)
+    /// This dictates what's returned in [`Writer::begin_variation`](super::Writer::begin_variation)
     /// and whether it does anything.
     ///
     /// Defaults to `|| false`.

--- a/pgn-reader/src/writer/config.rs
+++ b/pgn-reader/src/writer/config.rs
@@ -10,11 +10,7 @@ pub struct Config<Skip> {
     pub skip_variations: Skip,
     /// Defaults to `1`.
     pub starting_move_number: NonZeroUsize,
-    /// Whether to always include move numbers,
-    /// even if the parity does not match the starting move number parity.
-    ///
-    /// For example, if the starting move number is 1 (odd), a move number is even, and
-    /// this is set to `true`, that move number will be included.
+    /// Whether to always include move numbers.
     ///
     /// Defaults to `false`.
     pub always_include_move_number: bool,

--- a/pgn-reader/src/writer/config.rs
+++ b/pgn-reader/src/writer/config.rs
@@ -1,0 +1,59 @@
+use std::num::NonZeroUsize;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Config {
+    /// Whether to skip variations.
+    /// This only dictates what the [`Writer`](super::Writer) returns in [`Visitor::begin_variation`](crate::Visitor::begin_variation).
+    ///
+    /// Defaults to `false`.
+    pub skip_variations: bool,
+    /// Defaults to `1`.
+    pub starting_move_number: NonZeroUsize,
+    /// Whether to always include move numbers,
+    /// even if the parity does not match the starting move number parity.
+    ///
+    /// For example, if the starting move number is 1 (odd), a move number is even, and
+    /// this is set to `true`, that move number will be included.
+    ///
+    /// Defaults to `false`.
+    pub always_include_move_number: bool,
+    /// Whether to include a space after a move number (`"1. e4"` if `true`, `"1.e4"` otherwise).
+    ///
+    /// Defaults to `true`.
+    pub space_after_move_number: bool,
+    /// Whether to include spaces around variation parentheses (`"( "` and `") "` if `true`, `"("` and `")"` otherwise).
+    ///
+    /// Defaults to `true`.
+    pub space_around_variation: bool,
+    /// Whether to include spaces around comment braces (`"{ "` and `" } "` if `true`, `"{"` and `"}"` otherwise).
+    ///
+    /// Defaults to `true`.
+    pub space_around_comments: bool,
+}
+
+impl Config {
+    /// A space optimized [`Config`]. Not recommended as it won't make much of a difference
+    /// and might break certain parsers.
+    pub const COMPACT: Self = Self {
+        skip_variations: false,
+        starting_move_number: NonZeroUsize::new(1).unwrap(),
+        always_include_move_number: false,
+        space_after_move_number: false,
+        space_around_variation: false,
+        space_around_comments: false,
+    };
+}
+
+impl Default for Config {
+    /// Optimized for compatibility.
+    fn default() -> Self {
+        Self {
+            skip_variations: false,
+            starting_move_number: NonZeroUsize::MIN,
+            always_include_move_number: false,
+            space_after_move_number: true,
+            space_around_variation: true,
+            space_around_comments: true,
+        }
+    }
+}

--- a/pgn-reader/src/writer/error.rs
+++ b/pgn-reader/src/writer/error.rs
@@ -3,16 +3,10 @@ use std::io;
 /// Error when using [`Visitor`](crate::Visitor) methods on a [`Writer`](super::Writer).
 #[derive(Debug)]
 pub enum Error {
-    /// [`Writer::begin_variation`](super::Writer::begin_variation) was called before
-    /// any [`Writer::san`](super::Writer::san) was called.
-    ///
-    /// A movetext must not begin with a variation.
-    ImmediateVariation,
-    /// A method other than [`Writer::end_variation`](super::Writer::end_variation)
-    /// was called after [`Writer::outcome`](super::Writer::outcome) was called.
-    ///
-    /// Outcomes are the last thing that can appear in a variation, except for variation closing
-    /// parentheses.
-    WritingAfterOutcome,
+    /// A token ([`Visitor`](crate::Visitor) method) which was not allowed was called.
+    InvalidToken {
+        token: super::MovetextToken,
+        allowed: super::MovetextToken,
+    },
     Io(io::Error),
 }

--- a/pgn-reader/src/writer/error.rs
+++ b/pgn-reader/src/writer/error.rs
@@ -1,0 +1,18 @@
+use std::io;
+
+/// Error when using [`Visitor`](crate::Visitor) methods on a [`Writer`](super::Writer).
+#[derive(Debug)]
+pub enum Error {
+    /// [`Writer::begin_variation`](super::Writer::begin_variation) was called before
+    /// any [`Writer::san`](super::Writer::san) was called.
+    ///
+    /// A movetext must not begin with a variation.
+    ImmediateVariation,
+    /// A method other than [`Writer::end_variation`](super::Writer::end_variation)
+    /// was called after [`Writer::outcome`](super::Writer::outcome) was called.
+    ///
+    /// Outcomes are the last thing that can appear in a variation, except for variation closing
+    /// parentheses.
+    WritingAfterOutcome,
+    Io(io::Error),
+}

--- a/pgn-reader/src/writer/mod.rs
+++ b/pgn-reader/src/writer/mod.rs
@@ -464,13 +464,15 @@ where
     }
 
     /// Writes two newlines (`\n`).
-    fn end_game(&mut self, _: Self::Movetext) -> Self::Output {
+    fn end_game(&mut self, mut movetext: Self::Movetext) -> Self::Output {
         if !self.allowed_tokens.contains(MovetextToken::END_GAME) {
             return Err(Error::InvalidToken {
                 token: MovetextToken::END_GAME,
                 allowed: self.allowed_tokens,
             });
         }
+
+        while let ControlFlow::Continue(()) = self.end_variation(&mut movetext) {}
 
         self.writer
             .write(b"\n\n")
@@ -844,6 +846,6 @@ mod tests {
         assert_eq!(writer.writer, b"1. e4 ( d4 ( ( ( ) ");
 
         writer.end_game(movetext).unwrap();
-        assert_eq!(writer.writer, b"1. e4 ( d4 ( ( ( ) \n\n");
+        assert_eq!(writer.writer, b"1. e4 ( d4 ( ( ( ) ) ) ) \n\n");
     }
 }

--- a/pgn-reader/src/writer/mod.rs
+++ b/pgn-reader/src/writer/mod.rs
@@ -1,66 +1,11 @@
-use std::{io, io::Write, num::NonZeroUsize, ops::ControlFlow};
+mod config;
 
+use std::{io, io::Write, ops::ControlFlow};
+
+pub use config::Config;
 use shakmaty::{Outcome, san::SanPlus};
 
 use crate::{Nag, RawComment, RawTag, Skip, Visitor};
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Config {
-    /// Whether to skip variations.
-    /// This only dictates what the [`Writer`] returns in [`Visitor::begin_variation`].
-    ///
-    /// Defaults to `false`.
-    pub skip_variations: bool,
-    /// Defaults to `1`.
-    pub starting_move_number: NonZeroUsize,
-    /// Whether to always include move numbers,
-    /// even if the parity does not match the starting move number parity.
-    ///
-    /// For example, if the starting move number is 1 (odd), a move number is even, and
-    /// this is set to `true`, that move number will be included.
-    ///
-    /// Defaults to `false`.
-    pub always_include_move_number: bool,
-    /// Whether to include a space after a move number (`"1. e4"` if `true`, `"1.e4"` otherwise).
-    ///
-    /// Defaults to `true`.
-    pub space_after_move_number: bool,
-    /// Whether to include spaces around variation parentheses (`"( "` and `") "` if `true`, `"("` and `")"` otherwise).
-    ///
-    /// Defaults to `true`.
-    pub space_around_variation: bool,
-    /// Whether to include spaces around comment braces (`"{ "` and `" } "` if `true`, `"{"` and `"}"` otherwise).
-    ///
-    /// Defaults to `true`.
-    pub space_around_comments: bool,
-}
-
-impl Config {
-    /// A space optimized [`Config`]. Not recommended as it won't make much of a difference
-    /// and might break certain parsers.
-    pub const COMPACT: Self = Self {
-        skip_variations: false,
-        starting_move_number: NonZeroUsize::new(1).unwrap(),
-        always_include_move_number: false,
-        space_after_move_number: false,
-        space_around_variation: false,
-        space_around_comments: false,
-    };
-}
-
-impl Default for Config {
-    /// Optimized for compatibility.
-    fn default() -> Self {
-        Self {
-            skip_variations: false,
-            starting_move_number: NonZeroUsize::MIN,
-            always_include_move_number: false,
-            space_after_move_number: true,
-            space_around_variation: true,
-            space_around_comments: true,
-        }
-    }
-}
 
 /// Write a PGN using the [`Visitor`] implementation.
 #[derive(Debug)]
@@ -255,7 +200,7 @@ where
         }
     }
 
-    /// Writes a SAN.
+    /// Writes a [`SanPlus`].
     fn san(&mut self, _: &mut Self::Movetext, san_plus: SanPlus) -> ControlFlow<Self::Output> {
         self.buffer.clear();
 
@@ -292,6 +237,7 @@ where
         }
     }
 
+    /// Writes a [`Nag`].
     fn nag(&mut self, _: &mut Self::Movetext, nag: Nag) -> ControlFlow<Self::Output> {
         self.buffer.clear();
 
@@ -304,6 +250,7 @@ where
         }
     }
 
+    /// Writes a [`RawComment`] surrounded by braces.
     fn comment(
         &mut self,
         _: &mut Self::Movetext,

--- a/pgn-reader/tests/writer.rs
+++ b/pgn-reader/tests/writer.rs
@@ -59,7 +59,9 @@ fn normal() {
             )
             .continue_value()
             .unwrap();
-        writer.end_game(movetext).unwrap();
+        let bytes_written = writer.end_game(movetext).unwrap();
+
+        assert_eq!(bytes_written, writer.bytes_written());
 
         writer
     }
@@ -117,11 +119,12 @@ fn attempt_breakage() {
         .continue_value()
         .unwrap();
 
-    writer.end_game(movetext).unwrap();
+    let bytes_written = writer.end_game(movetext).unwrap();
 
     let correct1 = "1. Nc3 ( ( ( ) ) ) \n\n";
 
     assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct1);
+    assert_eq!(bytes_written, correct1.len());
     assert_eq!(writer.bytes_written(), correct1.len());
     assert_eq!(writer.total_bytes_written(), correct1.len());
 
@@ -140,13 +143,14 @@ fn attempt_breakage() {
         .continue_value()
         .unwrap();
 
-    writer.end_game(movetext).unwrap();
+    let bytes_written = writer.end_game(movetext).unwrap();
 
     let correct2 = r##"
 
 "##;
 
     assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct2);
+    assert_eq!(bytes_written, correct2.len());
     assert_eq!(writer.bytes_written(), correct2.len());
     assert_eq!(
         writer.total_bytes_written(),

--- a/pgn-reader/tests/writer.rs
+++ b/pgn-reader/tests/writer.rs
@@ -1,0 +1,166 @@
+use pgn_reader::{Nag, RawComment, RawTag, Visitor, Writer, writer};
+use shakmaty::{Color, KnownOutcome, Outcome, san::SanPlus};
+
+/// Normal usage of the writer.
+#[test]
+fn default() {
+    fn routine(mut writer: Writer<Vec<u8>>) -> Writer<Vec<u8>> {
+        let mut tags = writer.begin_tags().continue_value().unwrap();
+
+        writer
+            .tag(&mut tags, b"Event", RawTag(b"Testing\""))
+            .continue_value()
+            .unwrap();
+        writer
+            .tag(&mut tags, b"Site", RawTag(b"#[test]"))
+            .continue_value()
+            .unwrap();
+
+        let mut movetext = writer.begin_movetext(tags).continue_value().unwrap();
+
+        writer
+            .san(&mut movetext, SanPlus::from_ascii(b"exd4").unwrap())
+            .continue_value()
+            .unwrap();
+        writer
+            .san(&mut movetext, SanPlus::from_ascii(b"b2").unwrap())
+            .continue_value()
+            .unwrap();
+        let _ = writer
+            .begin_variation(&mut movetext)
+            .continue_value()
+            .unwrap();
+        writer
+            .san(&mut movetext, SanPlus::from_ascii(b"Qxg1").unwrap())
+            .continue_value()
+            .unwrap();
+        writer
+            .san(&mut movetext, SanPlus::from_ascii(b"Ke1#").unwrap())
+            .continue_value()
+            .unwrap();
+        writer
+            .comment(&mut movetext, RawComment(b"brilliant discovered mate"))
+            .continue_value()
+            .unwrap();
+        writer
+            .nag(&mut movetext, Nag::BRILLIANT_MOVE)
+            .continue_value()
+            .unwrap();
+        writer
+            .end_variation(&mut movetext)
+            .continue_value()
+            .unwrap();
+        writer
+            .outcome(
+                &mut movetext,
+                Outcome::Known(KnownOutcome::Decisive {
+                    winner: Color::White,
+                }),
+            )
+            .continue_value()
+            .unwrap();
+        writer.end_game(movetext).unwrap();
+
+        writer
+    }
+
+    let mut writer = Writer::new(Vec::new());
+    writer = routine(writer);
+
+    assert_eq!(
+        str::from_utf8(&writer.writer).unwrap(),
+        r##"[Event "Testing\""]
+[Site "#[test]"]
+
+1. exd4 b2 ( Qxg1 3. Ke1# { brilliant discovered mate } $3 ) 1-0
+
+"##
+    );
+
+    writer.writer.clear();
+    *writer.scheduled_config_mut() = writer::Config::COMPACT;
+
+    writer = routine(writer);
+
+    // space after certain tokens like moves and nags is necessary
+    assert_eq!(
+        str::from_utf8(&writer.writer).unwrap(),
+        r##"[Event "Testing\""]
+[Site "#[test]"]
+
+1.exd4 b2 (Qxg1 3.Ke1# {brilliant discovered mate}$3 )1-0
+
+"##
+    );
+}
+
+/// User tries to break the writer.
+#[test]
+fn attempt_breakage() {
+    let mut writer = Writer::new(Vec::new());
+    let mut tags = writer.begin_tags().continue_value().unwrap();
+
+    writer
+        .tag(&mut tags, b"Event", RawTag(b"Testing\""))
+        .continue_value()
+        .unwrap();
+    writer
+        .tag(&mut tags, b"Site", RawTag(b"#[test]"))
+        .continue_value()
+        .unwrap();
+
+    let mut movetext = writer.begin_movetext(tags).continue_value().unwrap();
+
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"exd4").unwrap())
+        .continue_value()
+        .unwrap();
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"b2").unwrap())
+        .continue_value()
+        .unwrap();
+    let _ = writer
+        .begin_variation(&mut movetext)
+        .continue_value()
+        .unwrap();
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"Qxg1").unwrap())
+        .continue_value()
+        .unwrap();
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"Ke1#").unwrap())
+        .continue_value()
+        .unwrap();
+    writer
+        .comment(&mut movetext, RawComment(b"brilliant discovered mate"))
+        .continue_value()
+        .unwrap();
+    writer
+        .nag(&mut movetext, Nag::BRILLIANT_MOVE)
+        .continue_value()
+        .unwrap();
+    writer
+        .end_variation(&mut movetext)
+        .continue_value()
+        .unwrap();
+    writer
+        .outcome(
+            &mut movetext,
+            Outcome::Known(KnownOutcome::Decisive {
+                winner: Color::White,
+            }),
+        )
+        .continue_value()
+        .unwrap();
+    writer.end_game(movetext).unwrap();
+
+    assert_eq!(
+        str::from_utf8(&writer.writer).unwrap(),
+        r##"[Event "Testing\""]
+[Site "#[test]"]
+
+1. exd4 b2 ( Qxg1 3. Ke1# { brilliant discovered mate } $3 ) 1-0
+
+"##
+    );
+}

--- a/pgn-reader/tests/writer.rs
+++ b/pgn-reader/tests/writer.rs
@@ -100,7 +100,6 @@ fn attempt_breakage() {
 
     let bytes_written = writer.end_game(movetext).unwrap();
 
-    // TODO: should unclosed variations be allowed?
     let correct1 = "1. Nc3 ( ( ( ) ) ) \n\n";
 
     assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct1);
@@ -110,30 +109,31 @@ fn attempt_breakage() {
 
     writer.writer.clear();
 
-    let tags = writer.begin_tags().continue_value().unwrap();
-    let mut movetext = writer.begin_movetext(tags).continue_value().unwrap();
-
-    writer
-        .end_variation(&mut movetext)
-        .continue_value()
-        .unwrap();
-
-    writer
-        .end_variation(&mut movetext)
-        .continue_value()
-        .unwrap();
-
-    let bytes_written = writer.end_game(movetext).unwrap();
-
-    let correct2 = r##"
-
-"##;
-
-    assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct2);
-    assert_eq!(bytes_written, correct2.len());
-    assert_eq!(writer.bytes_written(), correct2.len());
-    assert_eq!(
-        writer.total_bytes_written(),
-        correct1.len() + correct2.len()
-    );
+    // TODO: Should end_variation do nothing if there is nothing to close?
+//     let tags = writer.begin_tags().continue_value().unwrap();
+//     let mut movetext = writer.begin_movetext(tags).continue_value().unwrap();
+//
+//     writer
+//         .end_variation(&mut movetext)
+//         .continue_value()
+//         .unwrap();
+//
+//     writer
+//         .end_variation(&mut movetext)
+//         .continue_value()
+//         .unwrap();
+//
+//     let bytes_written = writer.end_game(movetext).unwrap();
+//
+//     let correct2 = r##"
+//
+// "##;
+//
+//     assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct2);
+//     assert_eq!(bytes_written, correct2.len());
+//     assert_eq!(writer.bytes_written(), correct2.len());
+//     assert_eq!(
+//         writer.total_bytes_written(),
+//         correct1.len() + correct2.len()
+//     );
 }

--- a/pgn-reader/tests/writer.rs
+++ b/pgn-reader/tests/writer.rs
@@ -3,7 +3,7 @@ use shakmaty::{Color, KnownOutcome, Outcome, san::SanPlus};
 
 /// Normal usage of the writer.
 #[test]
-fn default() {
+fn normal() {
     fn routine(mut writer: Writer<Vec<u8>>) -> Writer<Vec<u8>> {
         let mut tags = writer.begin_tags().continue_value().unwrap();
 
@@ -67,30 +67,25 @@ fn default() {
     let mut writer = Writer::new(Vec::new());
     writer = routine(writer);
 
-    assert_eq!(
-        str::from_utf8(&writer.writer).unwrap(),
-        r##"[Event "Testing\""]
-[Site "#[test]"]
+    let correct1 = "[Event \"Testing\\\"\"]\n[Site \"#[test]\"]\n\n1. exd4 b2 ( Qxg1 2. Ke1# { brilliant discovered mate } $3 ) 1-0 \n\n";
 
-1. exd4 b2 ( Qxg1 3. Ke1# { brilliant discovered mate } $3 ) 1-0
-
-"##
-    );
+    assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct1);
+    assert_eq!(writer.bytes_written(), correct1.len());
+    assert_eq!(writer.total_bytes_written(), correct1.len());
 
     writer.writer.clear();
     *writer.scheduled_config_mut() = writer::Config::COMPACT;
 
     writer = routine(writer);
 
+    let correct2 = "[Event \"Testing\\\"\"]\n[Site \"#[test]\"]\n\n1.exd4 b2 (Qxg1 2.Ke1# {brilliant discovered mate}$3 )1-0 \n\n";
+
     // space after certain tokens like moves and nags is necessary
+    assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct2);
+    assert_eq!(writer.bytes_written(), correct2.len());
     assert_eq!(
-        str::from_utf8(&writer.writer).unwrap(),
-        r##"[Event "Testing\""]
-[Site "#[test]"]
-
-1.exd4 b2 (Qxg1 3.Ke1# {brilliant discovered mate}$3 )1-0
-
-"##
+        writer.total_bytes_written(),
+        correct1.len() + correct2.len()
     );
 }
 
@@ -98,69 +93,63 @@ fn default() {
 #[test]
 fn attempt_breakage() {
     let mut writer = Writer::new(Vec::new());
-    let mut tags = writer.begin_tags().continue_value().unwrap();
-
-    writer
-        .tag(&mut tags, b"Event", RawTag(b"Testing\""))
-        .continue_value()
-        .unwrap();
-    writer
-        .tag(&mut tags, b"Site", RawTag(b"#[test]"))
-        .continue_value()
-        .unwrap();
-
+    let tags = writer.begin_tags().continue_value().unwrap();
     let mut movetext = writer.begin_movetext(tags).continue_value().unwrap();
 
     writer
-        .san(&mut movetext, SanPlus::from_ascii(b"exd4").unwrap())
+        .san(&mut movetext, SanPlus::from_ascii(b"Nc3").unwrap())
         .continue_value()
         .unwrap();
-    writer
-        .san(&mut movetext, SanPlus::from_ascii(b"b2").unwrap())
-        .continue_value()
-        .unwrap();
+
+    // unclosed variations
     let _ = writer
         .begin_variation(&mut movetext)
         .continue_value()
         .unwrap();
-    writer
-        .san(&mut movetext, SanPlus::from_ascii(b"Qxg1").unwrap())
+
+    let _ = writer
+        .begin_variation(&mut movetext)
         .continue_value()
         .unwrap();
-    writer
-        .san(&mut movetext, SanPlus::from_ascii(b"Ke1#").unwrap())
+
+    let _ = writer
+        .begin_variation(&mut movetext)
         .continue_value()
         .unwrap();
-    writer
-        .comment(&mut movetext, RawComment(b"brilliant discovered mate"))
-        .continue_value()
-        .unwrap();
-    writer
-        .nag(&mut movetext, Nag::BRILLIANT_MOVE)
-        .continue_value()
-        .unwrap();
+
+    writer.end_game(movetext).unwrap();
+
+    let correct1 = "1. Nc3 ( ( ( ) ) ) \n\n";
+
+    assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct1);
+    assert_eq!(writer.bytes_written(), correct1.len());
+    assert_eq!(writer.total_bytes_written(), correct1.len());
+
+    writer.writer.clear();
+
+    let tags = writer.begin_tags().continue_value().unwrap();
+    let mut movetext = writer.begin_movetext(tags).continue_value().unwrap();
+
     writer
         .end_variation(&mut movetext)
         .continue_value()
         .unwrap();
+
     writer
-        .outcome(
-            &mut movetext,
-            Outcome::Known(KnownOutcome::Decisive {
-                winner: Color::White,
-            }),
-        )
+        .end_variation(&mut movetext)
         .continue_value()
         .unwrap();
+
     writer.end_game(movetext).unwrap();
 
+    let correct2 = r##"
+
+"##;
+
+    assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct2);
+    assert_eq!(writer.bytes_written(), correct2.len());
     assert_eq!(
-        str::from_utf8(&writer.writer).unwrap(),
-        r##"[Event "Testing\""]
-[Site "#[test]"]
-
-1. exd4 b2 ( Qxg1 3. Ke1# { brilliant discovered mate } $3 ) 1-0
-
-"##
+        writer.total_bytes_written(),
+        correct1.len() + correct2.len()
     );
 }

--- a/pgn-reader/tests/writer.rs
+++ b/pgn-reader/tests/writer.rs
@@ -4,7 +4,7 @@ use shakmaty::{Color, KnownOutcome, Outcome, san::SanPlus};
 /// Normal usage of the writer.
 #[test]
 fn normal() {
-    fn routine(mut writer: Writer<Vec<u8>>) -> Writer<Vec<u8>> {
+    fn routine(mut writer: Writer<Vec<u8>, fn() -> bool>) -> Writer<Vec<u8>, fn() -> bool> {
         let mut tags = writer.begin_tags().continue_value().unwrap();
 
         writer
@@ -66,7 +66,7 @@ fn normal() {
         writer
     }
 
-    let mut writer = Writer::new(Vec::new());
+    let mut writer = Writer::new(Vec::new(), writer::Config::default());
     writer = routine(writer);
 
     let correct1 = "[Event \"Testing\\\"\"]\n[Site \"#[test]\"]\n\n1. exd4 b2 ( Qxg1 2. Ke1# { brilliant discovered mate } $3 ) 1-0 \n\n";
@@ -94,7 +94,7 @@ fn normal() {
 /// User tries to break the writer.
 #[test]
 fn attempt_breakage() {
-    let mut writer = Writer::new(Vec::new());
+    let mut writer = Writer::new(Vec::new(), writer::Config::default());
     let tags = writer.begin_tags().continue_value().unwrap();
     let mut movetext = writer.begin_movetext(tags).continue_value().unwrap();
 

--- a/pgn-reader/tests/writer.rs
+++ b/pgn-reader/tests/writer.rs
@@ -100,6 +100,7 @@ fn attempt_breakage() {
 
     let bytes_written = writer.end_game(movetext).unwrap();
 
+    // TODO: should unclosed variations be allowed?
     let correct1 = "1. Nc3 ( ( ( ) ) ) \n\n";
 
     assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct1);

--- a/pgn-reader/tests/writer.rs
+++ b/pgn-reader/tests/writer.rs
@@ -4,91 +4,70 @@ use shakmaty::{Color, KnownOutcome, Outcome, san::SanPlus};
 /// Normal usage of the writer.
 #[test]
 fn normal() {
-    fn routine(mut writer: Writer<Vec<u8>, fn() -> bool>) -> Writer<Vec<u8>, fn() -> bool> {
-        let mut tags = writer.begin_tags().continue_value().unwrap();
-
-        writer
-            .tag(&mut tags, b"Event", RawTag(b"Testing\""))
-            .continue_value()
-            .unwrap();
-        writer
-            .tag(&mut tags, b"Site", RawTag(b"#[test]"))
-            .continue_value()
-            .unwrap();
-
-        let mut movetext = writer.begin_movetext(tags).continue_value().unwrap();
-
-        writer
-            .san(&mut movetext, SanPlus::from_ascii(b"exd4").unwrap())
-            .continue_value()
-            .unwrap();
-        writer
-            .san(&mut movetext, SanPlus::from_ascii(b"b2").unwrap())
-            .continue_value()
-            .unwrap();
-        let _ = writer
-            .begin_variation(&mut movetext)
-            .continue_value()
-            .unwrap();
-        writer
-            .san(&mut movetext, SanPlus::from_ascii(b"Qxg1").unwrap())
-            .continue_value()
-            .unwrap();
-        writer
-            .san(&mut movetext, SanPlus::from_ascii(b"Ke1#").unwrap())
-            .continue_value()
-            .unwrap();
-        writer
-            .comment(&mut movetext, RawComment(b"brilliant discovered mate"))
-            .continue_value()
-            .unwrap();
-        writer
-            .nag(&mut movetext, Nag::BRILLIANT_MOVE)
-            .continue_value()
-            .unwrap();
-        writer
-            .end_variation(&mut movetext)
-            .continue_value()
-            .unwrap();
-        writer
-            .outcome(
-                &mut movetext,
-                Outcome::Known(KnownOutcome::Decisive {
-                    winner: Color::White,
-                }),
-            )
-            .continue_value()
-            .unwrap();
-        let bytes_written = writer.end_game(movetext).unwrap();
-
-        assert_eq!(bytes_written, writer.bytes_written());
-
-        writer
-    }
-
     let mut writer = Writer::new(Vec::new(), writer::Config::default());
-    writer = routine(writer);
+    let mut tags = writer.begin_tags().continue_value().unwrap();
 
-    let correct1 = "[Event \"Testing\\\"\"]\n[Site \"#[test]\"]\n\n1. exd4 b2 ( Qxg1 2. Ke1# { brilliant discovered mate } $3 ) 1-0 \n\n";
+    writer
+        .tag(&mut tags, b"Event", RawTag(b"Testing\""))
+        .continue_value()
+        .unwrap();
+    writer
+        .tag(&mut tags, b"Site", RawTag(b"#[test]"))
+        .continue_value()
+        .unwrap();
 
-    assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct1);
-    assert_eq!(writer.bytes_written(), correct1.len());
-    assert_eq!(writer.total_bytes_written(), correct1.len());
+    let mut movetext = writer.begin_movetext(tags).continue_value().unwrap();
 
-    writer.writer.clear();
-    *writer.scheduled_config_mut() = writer::Config::COMPACT;
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"exd4").unwrap())
+        .continue_value()
+        .unwrap();
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"b2").unwrap())
+        .continue_value()
+        .unwrap();
+    let _ = writer
+        .begin_variation(&mut movetext)
+        .continue_value()
+        .unwrap();
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"Qxg1").unwrap())
+        .continue_value()
+        .unwrap();
+    writer
+        .san(&mut movetext, SanPlus::from_ascii(b"Ke1#").unwrap())
+        .continue_value()
+        .unwrap();
+    writer
+        .comment(&mut movetext, RawComment(b"brilliant discovered mate"))
+        .continue_value()
+        .unwrap();
+    writer
+        .nag(&mut movetext, Nag::BRILLIANT_MOVE)
+        .continue_value()
+        .unwrap();
+    writer
+        .end_variation(&mut movetext)
+        .continue_value()
+        .unwrap();
+    writer
+        .outcome(
+            &mut movetext,
+            Outcome::Known(KnownOutcome::Decisive {
+                winner: Color::White,
+            }),
+        )
+        .continue_value()
+        .unwrap();
 
-    writer = routine(writer);
+    let bytes_written = writer.end_game(movetext).unwrap();
+    assert_eq!(bytes_written, writer.bytes_written());
 
-    let correct2 = "[Event \"Testing\\\"\"]\n[Site \"#[test]\"]\n\n1.exd4 b2 (Qxg1 2.Ke1# {brilliant discovered mate}$3 )1-0 \n\n";
+    let correct = "[Event \"Testing\\\"\"]\n[Site \"#[test]\"]\n\n1. exd4 b2 ( Qxg1 2. Ke1# { brilliant discovered mate } $3 ) 1-0 \n\n";
 
-    // space after certain tokens like moves and nags is necessary
-    assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct2);
-    assert_eq!(writer.bytes_written(), correct2.len());
-    assert_eq!(
-        writer.total_bytes_written(),
-        correct1.len() + correct2.len()
-    );
+    assert_eq!(str::from_utf8(&writer.writer).unwrap(), correct);
+    assert_eq!(writer.bytes_written(), correct.len());
+    assert_eq!(writer.total_bytes_written(), correct.len());
 }
 
 /// User tries to break the writer.


### PR DESCRIPTION
(not breaking)

- Adds a `Writer` struct to `pgn_reader` that implements `Visitor` by writing to an underlying `io::Write`.
- Adjusts doc language of `Visitor`.
- Tests, examples.

## Concerns

- Should `Writer::end_variation` do nothing if there is no variation to close? Right now, it errors.
- It's called pgn-*reader*. I would rename it to something like `shakmaty-pgn`. Before doing that though, I would ask the author of [`shakmaty-uci`](https://gitlab.com/Arcaik/shakmaty-uci) if he would be willing to transfer the crate, because IMHO, I've got a better implementation at [`ruci`](https://github.com/tigerros/ruci). You can see for yourself, but I'm pretty confident. The point is that if we want to commit to this pattern we should make sure other potential crates are available. Worth pointing out that `schach-{pgn,syzygy,uci,eco,core}` are all available if you wanted to do some rebranding. Or the even shorter `sach`. That might be too drastic though.

## Details

- `Writer` guarantees that the resulting PGN is syntactically valid.
- `Writer::end_game` automatically closes all variations.